### PR TITLE
 feat(i18n): add IT/EN/FR language selection

### DIFF
--- a/src/EdgePilot/App.cs
+++ b/src/EdgePilot/App.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
+using EdgePilot.Core;
 using EdgePilot.UI;
 using EdgePilot.Platform;
 using Avalonia.Threading;
@@ -12,13 +13,13 @@ namespace EdgePilot;
 public sealed class App : Application
 {
     private TrayIcon? _tray;
+    private NativeMenuItem? _settingsMenuItem;
+    private NativeMenuItem? _toggleMenuItem;
+    private NativeMenuItem? _exitMenuItem;
+
     public override void Initialize()
     {
-        var italian = System.Globalization.CultureInfo.GetCultureInfo("it-IT");
-        System.Globalization.CultureInfo.DefaultThreadCurrentCulture = italian;
-        System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = italian;
-        System.Globalization.CultureInfo.CurrentCulture = italian;
-        System.Globalization.CultureInfo.CurrentUICulture = italian;
+        Localization.SetLanguage(Localization.DetectSystemLanguage());
         Styles.Add(new FluentTheme());
         RequestedThemeVariant = OperatingSystem.IsLinux() ? ThemeVariant.Default : ThemeVariant.Dark;
     }
@@ -36,8 +37,9 @@ public sealed class App : Application
             {
                 preferences = new();
                 System.Diagnostics.Trace.WriteLine(ex);
-                warning = "Impossibile leggere le impostazioni salvate. Sono attive quelle predefinite. Premi Applica per salvare nuovamente le preferenze.";
+                warning = Localization.T("warning.loadFailed");
             }
+            if (preferences.Language is { } language) Localization.SetLanguage(language);
             // Preserve the existing development override without writing it to disk.
             if (Environment.GetEnvironmentVariable("EDGEPILOT_EDGE") is { Length: > 0 })
                 preferences = preferences with { Edge = EdgePlacement.FromEnvironment() };
@@ -46,7 +48,7 @@ public sealed class App : Application
             catch (Exception ex) when (ex is System.IO.IOException or UnauthorizedAccessException or System.Security.SecurityException)
             {
                 System.Diagnostics.Trace.WriteLine(ex);
-                warning = "Non è stato possibile verificare l’avvio automatico. Controlla le impostazioni.";
+                warning = Localization.T("warning.autostartCheckFailed");
             }
             var window = new EdgeWindow();
             window.SavePreferences = value => DesktopPreferences.Save(PreferenceStore.DefaultPath,
@@ -55,16 +57,16 @@ public sealed class App : Application
             try
             {
                 var menu = new NativeMenu();
-                var settings = new NativeMenuItem { Header = "Impostazioni" };
-                settings.Click += (_, _) => window.ShowSettings();
-                var toggle = new NativeMenuItem { Header = "Mostra / Nascondi pannello" };
-                toggle.Click += (_, _) => window.ToggleVisibility();
-                var exit = new NativeMenuItem { Header = "Esci" };
-                exit.Click += (_, _) => desktop.Shutdown();
-                menu.Items.Add(settings);
-                menu.Items.Add(toggle);
+                _settingsMenuItem = new NativeMenuItem { Header = Localization.T("tray.settings") };
+                _settingsMenuItem.Click += (_, _) => window.ShowSettings();
+                _toggleMenuItem = new NativeMenuItem { Header = Localization.T("tray.toggle") };
+                _toggleMenuItem.Click += (_, _) => window.ToggleVisibility();
+                _exitMenuItem = new NativeMenuItem { Header = Localization.T("tray.exit") };
+                _exitMenuItem.Click += (_, _) => desktop.Shutdown();
+                menu.Items.Add(_settingsMenuItem);
+                menu.Items.Add(_toggleMenuItem);
                 menu.Items.Add(new NativeMenuItemSeparator());
-                menu.Items.Add(exit);
+                menu.Items.Add(_exitMenuItem);
                 _tray = new TrayIcon { Icon = AppIcon.Load(), ToolTipText = "EdgePilot", Menu = menu, IsVisible = true };
                 _tray.Clicked += (_, _) => window.ShowSettings();
                 TrayIcon.SetIcons(this, new TrayIcons { _tray });
@@ -76,8 +78,15 @@ public sealed class App : Application
                 _tray?.Dispose();
                 _tray = null;
                 window.HasTray = false;
-                warning = "Icona nell’area di notifica non disponibile. Puoi riaprire le impostazioni avviando nuovamente EdgePilot.";
+                warning = Localization.T("warning.trayUnavailable");
             }
+            window.PreferencesChanged += () =>
+            {
+                if (_settingsMenuItem is null) return;
+                _settingsMenuItem.Header = Localization.T("tray.settings");
+                _toggleMenuItem!.Header = Localization.T("tray.toggle");
+                _exitMenuItem!.Header = Localization.T("tray.exit");
+            };
             SingleInstance.Bind(() => Dispatcher.UIThread.Post(() => window.ShowSettings()));
             window.ApplyPreferences(preferences);
             desktop.MainWindow = window;

--- a/src/EdgePilot/Core/Language.cs
+++ b/src/EdgePilot/Core/Language.cs
@@ -1,0 +1,3 @@
+namespace EdgePilot.Core;
+
+public enum Language { Italian, English, French }

--- a/src/EdgePilot/Core/Localization.cs
+++ b/src/EdgePilot/Core/Localization.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace EdgePilot.Core;
+
+public static class Localization
+{
+    public static Language Current { get; private set; } = Language.English;
+
+    public static Language DetectSystemLanguage() => CultureInfo.InstalledUICulture.TwoLetterISOLanguageName switch
+    {
+        "it" => Language.Italian,
+        "fr" => Language.French,
+        _ => Language.English
+    };
+
+    public static void SetLanguage(Language language)
+    {
+        Current = language;
+        var culture = CultureInfo.GetCultureInfo(language switch
+        {
+            Language.Italian => "it-IT",
+            Language.French => "fr-FR",
+            _ => "en-US"
+        });
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+    }
+
+    public static string T(string key) => Strings.Catalog.TryGetValue(key, out var translations)
+        ? translations[Current]
+        : key;
+
+    public static string T(string key, params object?[] args) => string.Format(T(key), args);
+}

--- a/src/EdgePilot/Core/Strings.cs
+++ b/src/EdgePilot/Core/Strings.cs
@@ -1,0 +1,172 @@
+namespace EdgePilot.Core;
+
+internal static class Strings
+{
+    public static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<Language, string>> Catalog = new Dictionary<string, IReadOnlyDictionary<Language, string>>
+    {
+        // Tray menu
+        ["tray.settings"] = Map("Impostazioni", "Settings", "Paramètres"),
+        ["tray.toggle"] = Map("Mostra / Nascondi pannello", "Show / Hide panel", "Afficher / Masquer le panneau"),
+        ["tray.exit"] = Map("Esci", "Exit", "Quitter"),
+
+        // App-level warnings
+        ["warning.loadFailed"] = Map(
+            "Impossibile leggere le impostazioni salvate. Sono attive quelle predefinite. Premi Applica per salvare nuovamente le preferenze.",
+            "Unable to read saved settings. Defaults are active. Press Apply to save your preferences again.",
+            "Impossible de lire les paramètres enregistrés. Les valeurs par défaut sont actives. Appuyez sur Appliquer pour enregistrer à nouveau vos préférences."),
+        ["warning.autostartCheckFailed"] = Map(
+            "Non è stato possibile verificare l'avvio automatico. Controlla le impostazioni.",
+            "Could not verify startup-at-login status. Check settings.",
+            "Impossible de vérifier le démarrage automatique. Vérifiez les paramètres."),
+        ["warning.trayUnavailable"] = Map(
+            "Icona nell'area di notifica non disponibile. Puoi riaprire le impostazioni avviando nuovamente EdgePilot.",
+            "Tray icon unavailable. You can reopen settings by launching EdgePilot again.",
+            "Icône de la zone de notification indisponible. Vous pouvez rouvrir les paramètres en relançant EdgePilot."),
+
+        // CLI (Program.cs)
+        ["cli.installedTo"] = Map("EdgePilot installato in {0}", "EdgePilot installed to {0}", "EdgePilot installé dans {0}"),
+        ["cli.installFailed"] = Map(
+            "Installazione non riuscita. Chiudi EdgePilot e riprova. {0}",
+            "Installation failed. Close EdgePilot and try again. {0}",
+            "Échec de l'installation. Fermez EdgePilot et réessayez. {0}"),
+        ["cli.alreadyRunning"] = Map(
+            "EdgePilot è già aperto ma non risponde. Chiudilo e riprova.",
+            "EdgePilot is already open but not responding. Close it and try again.",
+            "EdgePilot est déjà ouvert mais ne répond pas. Fermez-le et réessayez."),
+
+        // Drive selection
+        ["drive.auto"] = Map("Automatico (disco più capiente)", "Automatic (largest disk)", "Automatique (disque le plus grand)"),
+        ["drive.unavailableSuffix"] = Map("{0} · non disponibile", "{0} · unavailable", "{0} · indisponible"),
+
+        // Installer / autostart
+        ["installer.extractFirst"] = Map(
+            "Estrai il pacchetto in una cartella separata prima di installarlo.",
+            "Extract the package into a separate folder before installing it.",
+            "Extrayez le paquet dans un dossier séparé avant de l'installer."),
+        ["installer.startMenuUnavailable"] = Map("Menu Start non disponibile.", "Start menu unavailable.", "Menu Démarrer indisponible."),
+        ["desktop.comment"] = Map("Monitoraggio del sistema", "System monitoring", "Surveillance du système"),
+        ["autostart.pathUnavailable"] = Map("Percorso dell'app non disponibile.", "App path unavailable.", "Chemin de l'application indisponible."),
+        ["autostart.pathTooLong"] = Map(
+            "Percorso troppo lungo per l'avvio automatico di Windows.",
+            "Path too long for Windows startup registration.",
+            "Chemin trop long pour le démarrage automatique de Windows."),
+        ["autostart.invalidChars"] = Map(
+            "Il percorso dell'app contiene caratteri non supportati.",
+            "The app path contains unsupported characters.",
+            "Le chemin de l'application contient des caractères non pris en charge."),
+        ["autostart.updateFailed"] = Map(
+            "Impossibile aggiornare l'avvio automatico.",
+            "Unable to update startup-at-login registration.",
+            "Impossible de mettre à jour le démarrage automatique."),
+        ["appicon.unavailable"] = Map("Icona dell'app non disponibile.", "App icon unavailable.", "Icône de l'application indisponible."),
+
+        // Preferences validation (trace/log only, not shown to the user)
+        ["prefs.invalidEdgeMode"] = Map(
+            "Bordo o modalità di visualizzazione non supportati.",
+            "Unsupported edge or display mode.",
+            "Bord ou mode d'affichage non pris en charge."),
+        ["prefs.invalidRefresh"] = Map("Intervallo di aggiornamento non supportato.", "Unsupported refresh interval.", "Intervalle de rafraîchissement non pris en charge."),
+        ["prefs.invalidSensitivity"] = Map("Sensibilità non supportata.", "Unsupported sensitivity.", "Sensibilité non prise en charge."),
+        ["prefs.invalidMetrics"] = Map("Seleziona almeno una metrica valida.", "Select at least one valid metric.", "Sélectionnez au moins une métrique valide."),
+        ["prefs.invalidLanguage"] = Map("Lingua non supportata.", "Unsupported language.", "Langue non prise en charge."),
+        ["prefs.emptyFile"] = Map("Il file delle impostazioni è vuoto.", "The settings file is empty.", "Le fichier de paramètres est vide."),
+
+        // Uptime unit
+        ["time.dayUnit"] = Map("g", "d", "j"),
+
+        // Settings window
+        ["settings.title"] = Map("EdgePilot · Impostazioni", "EdgePilot · Settings", "EdgePilot · Paramètres"),
+        ["edge.right"] = Map("Destra", "Right", "Droite"),
+        ["edge.left"] = Map("Sinistra", "Left", "Gauche"),
+        ["edge.top"] = Map("Alto", "Top", "Haut"),
+        ["edge.bottom"] = Map("Basso", "Bottom", "Bas"),
+        ["mode.hover"] = Map("Al passaggio del mouse", "On hover", "Au survol"),
+        ["mode.always"] = Map("Sempre aperto", "Always open", "Toujours ouvert"),
+        ["mode.hidden"] = Map("Nascosto", "Hidden", "Masqué"),
+        ["refresh.0_5s"] = Map("Ogni 0,5 secondi", "Every 0.5 seconds", "Toutes les 0,5 secondes"),
+        ["refresh.1s"] = Map("Ogni secondo", "Every second", "Toutes les secondes"),
+        ["refresh.2s"] = Map("Ogni 2 secondi", "Every 2 seconds", "Toutes les 2 secondes"),
+        ["refresh.5s"] = Map("Ogni 5 secondi", "Every 5 seconds", "Toutes les 5 secondes"),
+        ["sensitivity.precise"] = Map("Precisa", "Precise", "Précise"),
+        ["sensitivity.normal"] = Map("Normale", "Normal", "Normale"),
+        ["sensitivity.wide"] = Map("Ampia", "Wide", "Large"),
+        ["metric.cpu"] = Map("CPU", "CPU", "CPU"),
+        ["metric.memory"] = Map("Memoria", "Memory", "Mémoire"),
+        ["metric.disk"] = Map("Disco", "Disk", "Disque"),
+        ["metric.network"] = Map("Rete", "Network", "Réseau"),
+        ["settings.autostart"] = Map("Avvia all'accesso", "Start at login", "Démarrer à la connexion"),
+        ["settings.exitButton"] = Map("Esci da EdgePilot", "Exit EdgePilot", "Quitter EdgePilot"),
+        ["settings.applyHint"] = Map("Premi Applica per salvare le modifiche.", "Press Apply to save your changes.", "Appuyez sur Appliquer pour enregistrer vos modifications."),
+        ["settings.apply"] = Map("Applica", "Apply", "Appliquer"),
+        ["settings.selectMetric"] = Map(
+            "Seleziona almeno una metrica da mostrare.",
+            "Select at least one metric to display.",
+            "Sélectionnez au moins une métrique à afficher."),
+        ["settings.hiddenWithTray"] = Map(
+            "Pannello nascosto. Usa l'icona nell'area di notifica per mostrarlo o riaprire le impostazioni.",
+            "Panel hidden. Use the tray icon to show it or reopen settings.",
+            "Panneau masqué. Utilisez l'icône de la zone de notification pour l'afficher ou rouvrir les paramètres."),
+        ["settings.hiddenNoTray"] = Map(
+            "Pannello nascosto. Scegli un'altra modalità per mostrarlo. Chiudendo le impostazioni esci da EdgePilot; al prossimo avvio tornerai qui.",
+            "Panel hidden. Choose a different mode to show it. Closing settings exits EdgePilot; you'll return here next time it starts.",
+            "Panneau masqué. Choisissez un autre mode pour l'afficher. Fermer les paramètres quitte EdgePilot ; vous reviendrez ici au prochain démarrage."),
+        ["settings.saved"] = Map(
+            "Impostazioni salvate. Fai clic destro sul pannello per riaprirle.",
+            "Settings saved. Right-click the panel to reopen them.",
+            "Paramètres enregistrés. Faites un clic droit sur le panneau pour les rouvrir."),
+        ["settings.saveFailed"] = Map(
+            "Impossibile salvare le impostazioni. Le preferenze attive non sono cambiate. Verifica i permessi di scrittura e lo spazio disponibile, poi riprova.",
+            "Unable to save settings. Your active preferences are unchanged. Check write permissions and available disk space, then try again.",
+            "Impossible d'enregistrer les paramètres. Vos préférences actives sont inchangées. Vérifiez les autorisations d'écriture et l'espace disponible, puis réessayez."),
+        ["settings.customize"] = Map("Personalizza EdgePilot", "Customize EdgePilot", "Personnaliser EdgePilot"),
+        ["settings.screenEdge"] = Map("Bordo dello schermo", "Screen edge", "Bord de l'écran"),
+        ["settings.displayMode"] = Map("Visualizzazione", "Display mode", "Mode d'affichage"),
+        ["settings.visibleMetrics"] = Map("Metriche visibili", "Visible metrics", "Métriques visibles"),
+        ["settings.dataRefresh"] = Map("Aggiornamento dei dati", "Data refresh", "Actualisation des données"),
+        ["settings.sensitivityLabel"] = Map("Sensibilità di apertura", "Opening sensitivity", "Sensibilité d'ouverture"),
+        ["settings.sensitivityHint"] = Map(
+            "Ampia: il pannello si apre anche passando vicino alla linguetta. Precisa: occorre avvicinarsi di più al bordo.",
+            "Wide: the panel opens even when passing near the tab. Precise: you need to get closer to the edge.",
+            "Large : le panneau s'ouvre même en passant près de l'onglet. Précise : il faut s'approcher davantage du bord."),
+        ["settings.driveLabel"] = Map("Disco da visualizzare", "Disk to display", "Disque à afficher"),
+        ["settings.driveHint"] = Map(
+            "Sono elencati i volumi montati e accessibili. Se manca un disco, montalo: l'elenco si aggiorna automaticamente.",
+            "Mounted, accessible volumes are listed. If a disk is missing, mount it: the list updates automatically.",
+            "Les volumes montés et accessibles sont listés. Si un disque manque, montez-le : la liste se met à jour automatiquement."),
+        ["settings.languageLabel"] = Map("Lingua", "Language", "Langue"),
+        ["language.auto"] = Map("Automatica (sistema)", "Automatic (system)", "Automatique (système)"),
+
+        // Notch tooltip / rings
+        ["ring.disk"] = Map("DISCO", "DISK", "DISQUE"),
+        ["ring.network"] = Map("RETE", "NETWORK", "RÉSEAU"),
+        ["tooltip.systemMonitoring"] = Map("MONITORAGGIO SISTEMA", "SYSTEM MONITORING", "SURVEILLANCE SYSTÈME"),
+        ["tooltip.error"] = Map("ERRORE", "ERROR", "ERREUR"),
+        ["tooltip.updateFailed"] = Map("Impossibile aggiornare i dati del sistema.", "Unable to refresh system data.", "Impossible d'actualiser les données système."),
+        ["tooltip.retryNext"] = Map("Nuovo tentativo al prossimo aggiornamento.", "Will retry on the next update.", "Nouvelle tentative à la prochaine mise à jour."),
+        ["network.yes"] = Map("SÌ", "YES", "OUI"),
+        ["network.no"] = Map("NO", "NO", "NON"),
+        ["tooltip.processors"] = Map("{0} processori logici", "{0} logical processors", "{0} processeurs logiques"),
+        ["tooltip.memory"] = Map("MEMORIA", "MEMORY", "MÉMOIRE"),
+        ["bytes.used"] = Map("{0} utilizzati", "{0} used", "{0} utilisés"),
+        ["bytes.available"] = Map("{0} disponibili", "{0} available", "{0} disponibles"),
+        ["bytes.total"] = Map("{0} totali", "{0} total", "{0} au total"),
+        ["tooltip.storage"] = Map("ARCHIVIAZIONE", "STORAGE", "STOCKAGE"),
+        ["storage.noDisk"] = Map("Nessun disco disponibile", "No disk available", "Aucun disque disponible"),
+        ["storage.unavailable"] = Map("Il disco scelto non è disponibile", "Selected disk unavailable", "Disque sélectionné indisponible"),
+        ["storage.chooseInSettings"] = Map("Scegli il disco nelle impostazioni.", "Choose the disk in settings.", "Choisissez le disque dans les paramètres."),
+        ["bytes.free"] = Map("{0} liberi", "{0} free", "{0} libres"),
+        ["tooltip.network"] = Map("RETE", "NETWORK", "RÉSEAU"),
+        ["network.connected"] = Map("CONNESSA", "CONNECTED", "CONNECTÉ"),
+        ["network.disconnected"] = Map("DISCONNESSA", "DISCONNECTED", "DÉCONNECTÉ"),
+        ["network.noInterface"] = Map("Nessuna interfaccia di rete attiva", "No active network interface", "Aucune interface réseau active"),
+        ["network.linkSpeed"] = Map("Velocità collegamento: {0} Mbps", "Link speed: {0} Mbps", "Vitesse de liaison : {0} Mbps"),
+        ["network.uptime"] = Map("Tempo di attività: {0}", "Uptime: {0}", "Disponibilité : {0}"),
+    };
+
+    private static IReadOnlyDictionary<Language, string> Map(string italian, string english, string french) => new Dictionary<Language, string>
+    {
+        [Language.Italian] = italian,
+        [Language.English] = english,
+        [Language.French] = french,
+    };
+}

--- a/src/EdgePilot/Platform/AutostartRegistration.cs
+++ b/src/EdgePilot/Platform/AutostartRegistration.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Win32;
+using EdgePilot.Core;
 using EdgePilot.UI;
 
 namespace EdgePilot.Platform;
@@ -14,12 +15,12 @@ public sealed record LaunchCommand(string Executable, IReadOnlyList<string> Argu
 {
     public static LaunchCommand Current()
     {
-        var executable = Environment.ProcessPath ?? throw new IOException("Percorso dell’app non disponibile.");
+        var executable = Environment.ProcessPath ?? throw new IOException(Localization.T("autostart.pathUnavailable"));
         var arguments = new List<string>();
         if (string.Equals(Path.GetFileNameWithoutExtension(executable), "dotnet", StringComparison.OrdinalIgnoreCase))
         {
             var assembly = Assembly.GetEntryAssembly()?.Location;
-            if (string.IsNullOrEmpty(assembly)) throw new IOException("Percorso dell’app non disponibile.");
+            if (string.IsNullOrEmpty(assembly)) throw new IOException(Localization.T("autostart.pathUnavailable"));
             arguments.Add(assembly);
         }
         arguments.Add("--autostart");
@@ -29,14 +30,14 @@ public sealed record LaunchCommand(string Executable, IReadOnlyList<string> Argu
     public string WindowsCommand()
     {
         var result = string.Join(" ", new[] { Executable }.Concat(Arguments).Select(QuoteWindows));
-        if (result.Length > 260) throw new IOException("Percorso troppo lungo per l’avvio automatico di Windows.");
+        if (result.Length > 260) throw new IOException(Localization.T("autostart.pathTooLong"));
         return result;
     }
 
     public string DesktopEntry()
     {
         var command = string.Join(" ", new[] { Executable }.Concat(Arguments).Select(QuoteDesktop));
-        return "[Desktop Entry]\nType=Application\nName=EdgePilot\nComment=Monitoraggio del sistema\nExec=" +
+        return $"[Desktop Entry]\nType=Application\nName=EdgePilot\nComment={Localization.T("desktop.comment")}\nExec=" +
             command.Replace("\\", "\\\\") +
             "\nTerminal=false\nX-GNOME-Autostart-enabled=true\n";
     }
@@ -44,7 +45,7 @@ public sealed record LaunchCommand(string Executable, IReadOnlyList<string> Argu
     private static void ValidateArgument(string value)
     {
         if (value.IndexOfAny(['\r', '\n', '\0']) >= 0)
-            throw new IOException("Il percorso dell’app contiene caratteri non supportati.");
+            throw new IOException(Localization.T("autostart.invalidChars"));
     }
 
     public static string QuoteWindows(string value)
@@ -103,7 +104,7 @@ public sealed class AutostartRegistration : IAutostartRegistration
         if (OperatingSystem.IsWindows())
         {
             using var key = Registry.CurrentUser.CreateSubKey(RunKey)
-                ?? throw new IOException("Impossibile aggiornare l’avvio automatico.");
+                ?? throw new IOException(Localization.T("autostart.updateFailed"));
             if (content is null) key.DeleteValue(ValueName, false);
             else key.SetValue(ValueName, content, RegistryValueKind.String);
             return;

--- a/src/EdgePilot/Platform/DesktopInstaller.cs
+++ b/src/EdgePilot/Platform/DesktopInstaller.cs
@@ -1,3 +1,5 @@
+using EdgePilot.Core;
+
 namespace EdgePilot.Platform;
 
 public static class DesktopInstaller
@@ -13,7 +15,7 @@ public static class DesktopInstaller
         if (!string.Equals(source, target, comparison))
         {
             if (target.StartsWith(source + Path.DirectorySeparatorChar, comparison))
-                throw new IOException("Estrai il pacchetto in una cartella separata prima di installarlo.");
+                throw new IOException(Localization.T("installer.extractFirst"));
             Directory.CreateDirectory(target);
             var options = new EnumerationOptions { RecurseSubdirectories = true, AttributesToSkip = FileAttributes.ReparsePoint };
             foreach (var file in Directory.EnumerateFiles(source, "*", options))
@@ -52,7 +54,7 @@ public static class DesktopInstaller
         if (!OperatingSystem.IsWindows()) return;
         var programs = Environment.GetFolderPath(Environment.SpecialFolder.Programs);
         Directory.CreateDirectory(programs);
-        var type = Type.GetTypeFromProgID("WScript.Shell") ?? throw new IOException("Menu Start non disponibile.");
+        var type = Type.GetTypeFromProgID("WScript.Shell") ?? throw new IOException(Localization.T("installer.startMenuUnavailable"));
         dynamic shell = Activator.CreateInstance(type)!;
         dynamic shortcut = shell.CreateShortcut(Path.Combine(programs, "EdgePilot.lnk"));
         shortcut.TargetPath = executable;

--- a/src/EdgePilot/Program.cs
+++ b/src/EdgePilot/Program.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using EdgePilot.Core;
 using EdgePilot.Platform;
 
 namespace EdgePilot;
@@ -8,6 +9,7 @@ internal static class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        Localization.SetLanguage(Localization.DetectSystemLanguage());
         if (args.Contains("--version"))
         {
             Console.WriteLine("EdgePilot " + typeof(Program).Assembly.GetName().Version);
@@ -15,10 +17,10 @@ internal static class Program
         }
         if (args.Contains("--install"))
         {
-            try { Console.WriteLine("EdgePilot installato in " + DesktopInstaller.Install()); }
+            try { Console.WriteLine(Localization.T("cli.installedTo", DesktopInstaller.Install())); }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Runtime.InteropServices.COMException)
             {
-                Console.Error.WriteLine("Installazione non riuscita. Chiudi EdgePilot e riprova. " + ex.Message);
+                Console.Error.WriteLine(Localization.T("cli.installFailed", ex.Message));
                 Environment.ExitCode = 1;
             }
             return;
@@ -28,7 +30,7 @@ internal static class Program
         {
             if (!args.Contains("--autostart") && !instance.NotifyPrimary())
             {
-                Console.Error.WriteLine("EdgePilot è già aperto ma non risponde. Chiudilo e riprova.");
+                Console.Error.WriteLine(Localization.T("cli.alreadyRunning"));
                 Environment.ExitCode = 1;
             }
             return;

--- a/src/EdgePilot/UI/AppIcon.cs
+++ b/src/EdgePilot/UI/AppIcon.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using EdgePilot.Core;
 
 namespace EdgePilot.UI;
 
@@ -7,7 +8,7 @@ public static class AppIcon
     public static WindowIcon Load()
     {
         using var stream = typeof(AppIcon).Assembly.GetManifestResourceStream("EdgePilot.Assets.edgepilot.ico")
-            ?? throw new IOException("Icona dell’app non disponibile.");
+            ?? throw new IOException(Localization.T("appicon.unavailable"));
         return new WindowIcon(stream);
     }
 }

--- a/src/EdgePilot/UI/DisplayFormat.cs
+++ b/src/EdgePilot/UI/DisplayFormat.cs
@@ -1,3 +1,5 @@
+using EdgePilot.Core;
+
 namespace EdgePilot.UI;
 
 internal static class DisplayFormat
@@ -23,7 +25,7 @@ internal static class DisplayFormat
 
     public static string Uptime(TimeSpan uptime)
     {
-        if (uptime.TotalDays >= 1) return $"{(int)uptime.TotalDays} g {uptime.Hours} h {uptime.Minutes} min";
+        if (uptime.TotalDays >= 1) return $"{(int)uptime.TotalDays} {Localization.T("time.dayUnit")} {uptime.Hours} h {uptime.Minutes} min";
         if (uptime.TotalHours >= 1) return $"{uptime.Hours} h {uptime.Minutes} min";
         return $"{uptime.Minutes} min {uptime.Seconds} s";
     }

--- a/src/EdgePilot/UI/DriveSelection.cs
+++ b/src/EdgePilot/UI/DriveSelection.cs
@@ -20,7 +20,7 @@ public static class DriveSelection
 
     public static IReadOnlyList<DriveChoice> Choices(IReadOnlyList<DriveSnapshot> drives, string? selected)
     {
-        var choices = new List<DriveChoice> { new(null, "Automatico (disco più capiente)") };
+        var choices = new List<DriveChoice> { new(null, Localization.T("drive.auto")) };
         foreach (var drive in drives)
         {
             var capacity = drive.TotalBytes >= 1_000_000_000_000L
@@ -29,7 +29,7 @@ public static class DriveSelection
             choices.Add(new(drive.Name, $"{drive.Label} · {drive.Name} · {capacity}"));
         }
         if (selected is not null && Resolve(drives, selected) is null)
-            choices.Add(new(selected, $"{selected} · non disponibile"));
+            choices.Add(new(selected, Localization.T("drive.unavailableSuffix", selected)));
         return choices;
     }
 }

--- a/src/EdgePilot/UI/EdgeWindow.cs
+++ b/src/EdgePilot/UI/EdgeWindow.cs
@@ -65,8 +65,10 @@ public sealed class EdgeWindow : Window
     private NotchDisplayMode _mode;
     private string? _selectedDrive;
     private bool _startAtLogin;
+    private Language? _language;
     public bool HasTray { get; set; }
     public event Action? ExitRequested;
+    public event Action? PreferencesChanged;
     public Action<NotchPreferences>? SavePreferences { get; set; }
     private SettingsWindow? _settingsWindow;
     private int? _hoveredMetric;
@@ -97,8 +99,8 @@ public sealed class EdgeWindow : Window
 
         _cpuRing = new MetricRing("C", "CPU");
         _ramRing = new MetricRing("M", "RAM");
-        _diskRing = new MetricRing("D", "DISCO");
-        _networkRing = new MetricRing("↕", "RETE");
+        _diskRing = new MetricRing("D", Localization.T("ring.disk"));
+        _networkRing = new MetricRing("↕", Localization.T("ring.network"));
 
         _metricStack = new StackPanel
         {
@@ -249,11 +251,11 @@ public sealed class EdgeWindow : Window
     {
         Dispatcher.UIThread.Post(() =>
         {
-            _tooltipTitle.Text = "MONITORAGGIO SISTEMA";
-            _tooltipValue.Text = "ERRORE";
+            _tooltipTitle.Text = Localization.T("tooltip.systemMonitoring");
+            _tooltipValue.Text = Localization.T("tooltip.error");
             System.Diagnostics.Trace.WriteLine(exception);
-            _tooltipLine1.Text = "Impossibile aggiornare i dati del sistema.";
-            _tooltipLine2.Text = "Nuovo tentativo al prossimo aggiornamento.";
+            _tooltipLine1.Text = Localization.T("tooltip.updateFailed");
+            _tooltipLine2.Text = Localization.T("tooltip.retryNext");
             _tooltipLine3.Text = "";
         });
     }
@@ -270,7 +272,7 @@ public sealed class EdgeWindow : Window
         _cpuRing.SetValue(cpu, $"{cpu:0}%");
         _ramRing.SetValue(ram, $"{ram:0}%");
         _diskRing.SetValue(drive?.UsedPercent, drive is null ? "—" : $"{drive.UsedPercent:0}%");
-        _networkRing.SetValue(null, snapshot.Network.Connected ? "SÌ" : "NO");
+        _networkRing.SetValue(null, snapshot.Network.Connected ? Localization.T("network.yes") : Localization.T("network.no"));
 
         if (_hoveredMetric is not null)
         {
@@ -446,47 +448,47 @@ public sealed class EdgeWindow : Window
             case 0:
                 _tooltipTitle.Text = "CPU";
                 _tooltipValue.Text = $"{cpu:0}%";
-                _tooltipLine1.Text = $"{Environment.ProcessorCount} processori logici";
+                _tooltipLine1.Text = Localization.T("tooltip.processors", Environment.ProcessorCount);
                 _tooltipLine2.Text = snapshot.HostName;
                 _tooltipLine3.Text = snapshot.OperatingSystem;
                 break;
 
             case 1:
-                _tooltipTitle.Text = "MEMORIA";
+                _tooltipTitle.Text = Localization.T("tooltip.memory");
                 _tooltipValue.Text = $"{ram:0}%";
-                _tooltipLine1.Text = $"{DisplayFormat.Bytes(snapshot.MemoryUsedBytes)} utilizzati";
-                _tooltipLine2.Text = $"{DisplayFormat.Bytes(snapshot.MemoryAvailableBytes)} disponibili";
-                _tooltipLine3.Text = $"{DisplayFormat.Bytes(snapshot.MemoryTotalBytes)} totali";
+                _tooltipLine1.Text = Localization.T("bytes.used", DisplayFormat.Bytes(snapshot.MemoryUsedBytes));
+                _tooltipLine2.Text = Localization.T("bytes.available", DisplayFormat.Bytes(snapshot.MemoryAvailableBytes));
+                _tooltipLine3.Text = Localization.T("bytes.total", DisplayFormat.Bytes(snapshot.MemoryTotalBytes));
                 break;
 
             case 2:
-                _tooltipTitle.Text = "ARCHIVIAZIONE";
+                _tooltipTitle.Text = Localization.T("tooltip.storage");
                 if (drive is null)
                 {
                     _tooltipValue.Text = "—";
-                    _tooltipLine1.Text = _selectedDrive is null ? "Nessun disco disponibile" : "Il disco scelto non è disponibile";
+                    _tooltipLine1.Text = _selectedDrive is null ? Localization.T("storage.noDisk") : Localization.T("storage.unavailable");
                     _tooltipLine2.Text = _selectedDrive ?? "";
-                    _tooltipLine3.Text = "Scegli il disco nelle impostazioni.";
+                    _tooltipLine3.Text = Localization.T("storage.chooseInSettings");
                 }
                 else
                 {
                     _tooltipValue.Text = $"{drive.UsedPercent:0}%";
                     _tooltipLine1.Text = drive.Label;
-                    _tooltipLine2.Text = $"{DisplayFormat.Bytes(drive.FreeBytes)} liberi";
-                    _tooltipLine3.Text = $"{DisplayFormat.Bytes(drive.TotalBytes)} totali";
+                    _tooltipLine2.Text = Localization.T("bytes.free", DisplayFormat.Bytes(drive.FreeBytes));
+                    _tooltipLine3.Text = Localization.T("bytes.total", DisplayFormat.Bytes(drive.TotalBytes));
                 }
                 break;
 
             default:
-                _tooltipTitle.Text = "RETE";
-                _tooltipValue.Text = snapshot.Network.Connected ? "CONNESSA" : "DISCONNESSA";
-                _tooltipLine1.Text = snapshot.Network.Connected ? snapshot.Network.InterfaceName : "Nessuna interfaccia di rete attiva";
+                _tooltipTitle.Text = Localization.T("tooltip.network");
+                _tooltipValue.Text = snapshot.Network.Connected ? Localization.T("network.connected") : Localization.T("network.disconnected");
+                _tooltipLine1.Text = snapshot.Network.Connected ? snapshot.Network.InterfaceName : Localization.T("network.noInterface");
                 _tooltipLine2.Text = snapshot.Network.Connected
                     ? $"↓ {DisplayFormat.Rate(snapshot.Network.ReceiveBytesPerSecond)}   ↑ {DisplayFormat.Rate(snapshot.Network.SendBytesPerSecond)}"
                     : "";
                 _tooltipLine3.Text = snapshot.Network.LinkSpeedBitsPerSecond > 0
-                    ? $"Velocità collegamento: {snapshot.Network.LinkSpeedBitsPerSecond / 1_000_000d:0} Mbps"
-                    : $"Tempo di attività: {DisplayFormat.Uptime(snapshot.Uptime)}";
+                    ? Localization.T("network.linkSpeed", (int)Math.Round(snapshot.Network.LinkSpeedBitsPerSecond / 1_000_000d))
+                    : Localization.T("network.uptime", DisplayFormat.Uptime(snapshot.Uptime));
                 break;
         }
     }
@@ -495,7 +497,8 @@ public sealed class EdgeWindow : Window
     {
         SelectedDrive = _selectedDrive, StartAtLogin = _startAtLogin,
         Metrics = _metrics, Sensitivity = _sensitivity,
-        RefreshIntervalMs = (int)_monitor.RefreshInterval.TotalMilliseconds
+        RefreshIntervalMs = (int)_monitor.RefreshInterval.TotalMilliseconds,
+        Language = _language
     };
 
     public void ApplyPreferences(NotchPreferences preferences)
@@ -510,6 +513,10 @@ public sealed class EdgeWindow : Window
         _startAtLogin = preferences.StartAtLogin;
         _metrics = preferences.Metrics;
         _sensitivity = preferences.Sensitivity;
+        _language = preferences.Language;
+        Localization.SetLanguage(preferences.Language ?? Localization.DetectSystemLanguage());
+        _diskRing.SetCaption(Localization.T("ring.disk"));
+        _networkRing.SetCaption(Localization.T("ring.network"));
         _monitor.RefreshInterval = TimeSpan.FromMilliseconds(preferences.RefreshIntervalMs);
         _visibleMetricIndices = Enumerable.Range(0, 4).Where(i => ((int)_metrics & (1 << i)) != 0).ToArray();
         _metricStack.Children.Clear();
@@ -534,6 +541,7 @@ public sealed class EdgeWindow : Window
         }
         if (_latestSnapshot is not null) RenderSnapshot(_latestSnapshot);
         Relocate();
+        PreferencesChanged?.Invoke();
     }
 
     public void RequestExit()
@@ -558,7 +566,7 @@ public sealed class EdgeWindow : Window
         CancelFold();
         _settingsWindow = new SettingsWindow(Preferences, ApplyPreferences, warning,
             drives: _latestSnapshot?.Drives, savePreferences: SavePreferences,
-            exit: RequestExit, hasTray: HasTray);
+            exit: RequestExit, hasTray: HasTray, reopen: () => Dispatcher.UIThread.Post(() => ShowSettings()));
         _settingsWindow.Closed += (_, _) =>
         {
             _settingsWindow = null;

--- a/src/EdgePilot/UI/MetricRing.cs
+++ b/src/EdgePilot/UI/MetricRing.cs
@@ -15,6 +15,7 @@ internal sealed class MetricRing : StackPanel
     private readonly Path _progress;
     private readonly TextBlock _glyph;
     private readonly TextBlock _value;
+    private readonly TextBlock _label;
 
     public MetricRing(string glyph, string caption)
     {
@@ -74,7 +75,7 @@ internal sealed class MetricRing : StackPanel
             TextAlignment = TextAlignment.Center
         };
 
-        var label = new TextBlock
+        _label = new TextBlock
         {
             Text = caption,
             FontSize = 8,
@@ -87,7 +88,7 @@ internal sealed class MetricRing : StackPanel
 
         Children.Add(ring);
         Children.Add(_value);
-        Children.Add(label);
+        Children.Add(_label);
 
         SetValue(null, "—");
     }
@@ -100,6 +101,8 @@ internal sealed class MetricRing : StackPanel
     }
 
     public void SetGlyph(string glyph) => _glyph.Text = glyph;
+
+    public void SetCaption(string caption) => _label.Text = caption;
 
     private static Geometry Arc(double percent)
     {

--- a/src/EdgePilot/UI/NotchPreferences.cs
+++ b/src/EdgePilot/UI/NotchPreferences.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using EdgePilot.Core;
 
 namespace EdgePilot.UI;
 
@@ -17,6 +18,8 @@ public sealed record NotchPreferences(EdgeSide Edge = EdgeSide.Right,
     public int RefreshIntervalMs { get; init; } = 1000;
     public HoverSensitivity Sensitivity { get; init; } = HoverSensitivity.Normal;
     public VisibleMetrics Metrics { get; init; } = VisibleMetrics.All;
+    // Null means "follow the system language".
+    public Language? Language { get; init; }
 }
 
 public static class PreferenceStore
@@ -34,20 +37,22 @@ public static class PreferenceStore
     public static void Validate(NotchPreferences value)
     {
         if (!Enum.IsDefined(value.Edge) || !Enum.IsDefined(value.Mode))
-            throw new InvalidDataException("Bordo o modalità di visualizzazione non supportati.");
+            throw new InvalidDataException(Localization.T("prefs.invalidEdgeMode"));
         if (value.RefreshIntervalMs is not (500 or 1000 or 2000 or 5000))
-            throw new InvalidDataException("Intervallo di aggiornamento non supportato.");
+            throw new InvalidDataException(Localization.T("prefs.invalidRefresh"));
         if (!Enum.IsDefined(value.Sensitivity))
-            throw new InvalidDataException("Sensibilità non supportata.");
+            throw new InvalidDataException(Localization.T("prefs.invalidSensitivity"));
         if (value.Metrics == 0 || (value.Metrics & ~VisibleMetrics.All) != 0)
-            throw new InvalidDataException("Seleziona almeno una metrica valida.");
+            throw new InvalidDataException(Localization.T("prefs.invalidMetrics"));
+        if (value.Language is { } language && !Enum.IsDefined(language))
+            throw new InvalidDataException(Localization.T("prefs.invalidLanguage"));
     }
 
     public static NotchPreferences Load(string path)
     {
         if (!File.Exists(path)) return new();
         var value = JsonSerializer.Deserialize<NotchPreferences>(File.ReadAllText(path), Options)
-            ?? throw new InvalidDataException("Il file delle impostazioni è vuoto.");
+            ?? throw new InvalidDataException(Localization.T("prefs.emptyFile"));
         Validate(value);
         return value;
     }

--- a/src/EdgePilot/UI/SettingsWindow.cs
+++ b/src/EdgePilot/UI/SettingsWindow.cs
@@ -7,13 +7,18 @@ namespace EdgePilot.UI;
 
 public sealed class SettingsWindow : Window
 {
+    private sealed record LanguageChoice(Language? Value, string Caption)
+    {
+        public override string ToString() => Caption;
+    }
+
     private readonly ComboBox _drive;
     private readonly string? _initialDrive;
     public SettingsWindow(NotchPreferences current, Action<NotchPreferences> apply, string? warning = null, string? storagePath = null,
         IReadOnlyList<DriveSnapshot>? drives = null, Action<NotchPreferences>? savePreferences = null,
-        Action? exit = null, bool hasTray = false)
+        Action? exit = null, bool hasTray = false, Action? reopen = null)
     {
-        Title = "EdgePilot · Impostazioni";
+        Title = Localization.T("settings.title");
         Width = 480;
         MinWidth = 420;
         MinHeight = 400;
@@ -23,31 +28,31 @@ public sealed class SettingsWindow : Window
         WindowStartupLocation = WindowStartupLocation.CenterScreen;
         var edge = new ComboBox
         {
-            ItemsSource = new[] { "Destra", "Sinistra", "Alto", "Basso" },
+            ItemsSource = new[] { Localization.T("edge.right"), Localization.T("edge.left"), Localization.T("edge.top"), Localization.T("edge.bottom") },
             SelectedIndex = (int)current.Edge,
             HorizontalAlignment = HorizontalAlignment.Stretch
         };
         var mode = new ComboBox
         {
-            ItemsSource = new[] { "Al passaggio del mouse", "Sempre aperto", "Nascosto" },
+            ItemsSource = new[] { Localization.T("mode.hover"), Localization.T("mode.always"), Localization.T("mode.hidden") },
             SelectedIndex = (int)current.Mode,
             HorizontalAlignment = HorizontalAlignment.Stretch
         };
         var intervals = new[] { 500, 1000, 2000, 5000 };
         var refresh = new ComboBox
         {
-            ItemsSource = new[] { "Ogni 0,5 secondi", "Ogni secondo", "Ogni 2 secondi", "Ogni 5 secondi" },
+            ItemsSource = new[] { Localization.T("refresh.0_5s"), Localization.T("refresh.1s"), Localization.T("refresh.2s"), Localization.T("refresh.5s") },
             SelectedIndex = Array.IndexOf(intervals, current.RefreshIntervalMs),
             HorizontalAlignment = HorizontalAlignment.Stretch
         };
         var sensitivity = new ComboBox
         {
-            ItemsSource = new[] { "Precisa", "Normale", "Ampia" },
+            ItemsSource = new[] { Localization.T("sensitivity.precise"), Localization.T("sensitivity.normal"), Localization.T("sensitivity.wide") },
             SelectedIndex = (int)current.Sensitivity,
             HorizontalAlignment = HorizontalAlignment.Stretch
         };
         var metricOptions = new[] { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
-        var metricNames = new[] { "CPU", "Memoria", "Disco", "Rete" };
+        var metricNames = new[] { Localization.T("metric.cpu"), Localization.T("metric.memory"), Localization.T("metric.disk"), Localization.T("metric.network") };
         var metrics = metricOptions.Select((flag, index) => new CheckBox
         {
             Content = metricNames[index], IsChecked = current.Metrics.HasFlag(flag)
@@ -58,6 +63,19 @@ public sealed class SettingsWindow : Window
             metric.Margin = new Thickness(0, 0, 16, 0);
             metricPanel.Children.Add(metric);
         }
+        var languageChoices = new[]
+        {
+            new LanguageChoice(null, Localization.T("language.auto")),
+            new LanguageChoice(Language.Italian, "Italiano"),
+            new LanguageChoice(Language.English, "English"),
+            new LanguageChoice(Language.French, "Français"),
+        };
+        var language = new ComboBox
+        {
+            ItemsSource = languageChoices,
+            SelectedIndex = Array.FindIndex(languageChoices, c => c.Value == current.Language),
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
         _initialDrive = current.SelectedDrive;
         _drive = new ComboBox
         {
@@ -65,15 +83,15 @@ public sealed class SettingsWindow : Window
             MaxDropDownHeight = 280
         };
         UpdateDrives(drives ?? Array.Empty<DriveSnapshot>());
-        var autostart = new CheckBox { Content = "Avvia all’accesso", IsChecked = current.StartAtLogin };
-        var exitButton = new Button { Content = "Esci da EdgePilot" };
+        var autostart = new CheckBox { Content = Localization.T("settings.autostart"), IsChecked = current.StartAtLogin };
+        var exitButton = new Button { Content = Localization.T("settings.exitButton") };
         exitButton.Click += (_, _) => { if (exit is not null) exit(); else Close(); };
         var message = new TextBlock
         {
-            Text = warning ?? "Premi Applica per salvare le modifiche.",
+            Text = warning ?? Localization.T("settings.applyHint"),
             TextWrapping = Avalonia.Media.TextWrapping.Wrap
         };
-        var applyButton = new Button { Content = "Applica", HorizontalAlignment = HorizontalAlignment.Right };
+        var applyButton = new Button { Content = Localization.T("settings.apply"), HorizontalAlignment = HorizontalAlignment.Right };
         applyButton.Click += (_, _) =>
         {
             VisibleMetrics selected = 0;
@@ -81,7 +99,7 @@ public sealed class SettingsWindow : Window
                 if (metrics[i].IsChecked == true) selected |= metricOptions[i];
             if (selected == 0)
             {
-                message.Text = "Seleziona almeno una metrica da mostrare.";
+                message.Text = Localization.T("settings.selectMetric");
                 return;
             }
             var value = new NotchPreferences((EdgeSide)edge.SelectedIndex, (NotchDisplayMode)mode.SelectedIndex)
@@ -90,22 +108,30 @@ public sealed class SettingsWindow : Window
                 Sensitivity = (HoverSensitivity)sensitivity.SelectedIndex,
                 Metrics = selected,
                 SelectedDrive = (_drive.SelectedItem as DriveChoice)?.Name,
-                StartAtLogin = autostart.IsChecked == true
+                StartAtLogin = autostart.IsChecked == true,
+                Language = (language.SelectedItem as LanguageChoice)?.Value
             };
+            var languageChanged = value.Language != current.Language;
             try
             {
                 if (savePreferences is not null) savePreferences(value);
                 else PreferenceStore.Save(storagePath ?? PreferenceStore.DefaultPath, value);
                 apply(value);
+                if (languageChanged)
+                {
+                    reopen?.Invoke();
+                    Close();
+                    return;
+                }
                 message.Text = value.Mode == NotchDisplayMode.Hidden
-                    ? (hasTray ? "Pannello nascosto. Usa l’icona nell’area di notifica per mostrarlo o riaprire le impostazioni."
-                        : "Pannello nascosto. Scegli un’altra modalità per mostrarlo. Chiudendo le impostazioni esci da EdgePilot; al prossimo avvio tornerai qui.")
-                    : "Impostazioni salvate. Fai clic destro sul pannello per riaprirle.";
+                    ? (hasTray ? Localization.T("settings.hiddenWithTray")
+                        : Localization.T("settings.hiddenNoTray"))
+                    : Localization.T("settings.saved");
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or System.Security.SecurityException)
             {
                 System.Diagnostics.Trace.WriteLine(ex);
-                message.Text = "Impossibile salvare le impostazioni. Le preferenze attive non sono cambiate. Verifica i permessi di scrittura e lo spazio disponibile, poi riprova.";
+                message.Text = Localization.T("settings.saveFailed");
             }
         };
         Content = new ScrollViewer { Content = new StackPanel
@@ -114,23 +140,24 @@ public sealed class SettingsWindow : Window
             Spacing = 12,
             Children =
             {
-                new TextBlock { Text = "Personalizza EdgePilot", FontSize = 22 },
-                new TextBlock { Text = "Bordo dello schermo" }, edge,
-                new TextBlock { Text = "Visualizzazione" }, mode,
-                new TextBlock { Text = "Metriche visibili" }, metricPanel,
-                new TextBlock { Text = "Aggiornamento dei dati" }, refresh,
-                new TextBlock { Text = "Sensibilità di apertura" }, sensitivity,
+                new TextBlock { Text = Localization.T("settings.customize"), FontSize = 22 },
+                new TextBlock { Text = Localization.T("settings.screenEdge") }, edge,
+                new TextBlock { Text = Localization.T("settings.displayMode") }, mode,
+                new TextBlock { Text = Localization.T("settings.visibleMetrics") }, metricPanel,
+                new TextBlock { Text = Localization.T("settings.dataRefresh") }, refresh,
+                new TextBlock { Text = Localization.T("settings.sensitivityLabel") }, sensitivity,
                 new TextBlock
                 {
-                    Text = "Ampia: il pannello si apre anche passando vicino alla linguetta. Precisa: occorre avvicinarsi di più al bordo.",
+                    Text = Localization.T("settings.sensitivityHint"),
                     TextWrapping = Avalonia.Media.TextWrapping.Wrap
                 },
-                new TextBlock { Text = "Disco da visualizzare" }, _drive,
+                new TextBlock { Text = Localization.T("settings.driveLabel") }, _drive,
                 new TextBlock
                 {
-                    Text = "Sono elencati i volumi montati e accessibili. Se manca un disco, montalo: l’elenco si aggiorna automaticamente.",
+                    Text = Localization.T("settings.driveHint"),
                     TextWrapping = Avalonia.Media.TextWrapping.Wrap
                 },
+                new TextBlock { Text = Localization.T("settings.languageLabel") }, language,
                 autostart,
                 message, applyButton,
                 new StackPanel { Children = { exitButton } }


### PR DESCRIPTION
## Problem and resulting behavior
- The interface was entirely hardcoded in Italian, with no translation mechanism. Adds a string catalog kept separate from the logic, automatic detection of the system language, and a manual selector in Settings, to open the app to English- and French-speaking users without taking anything away from existing Italian users.

## Verification
Tested on Windows 11

## Screenshots

French: 
<img width="362" height="688" alt="image" src="https://github.com/user-attachments/assets/211b3ce1-3ac4-4a3e-bc28-86f485f390cd" />
<img width="308" height="465" alt="image" src="https://github.com/user-attachments/assets/6642e6f6-07b2-457e-b765-8d3f46ea5224" />

English:
<img width="362" height="677" alt="image" src="https://github.com/user-attachments/assets/e1f4fe1d-7b48-438c-b44e-85222a4faa8f" />
<img width="308" height="465" alt="image" src="https://github.com/user-attachments/assets/0ac2507e-f357-4c5b-a159-c1dd6e4d71fd" />
