### PR TITLE
v0.2 preview: redesign settings experience

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Notch UX regression checks
         run: dotnet run --project tests/EdgePilot.UxChecks --configuration Release
 
+      - name: Localization regression checks
+        run: dotnet run --project tests/EdgePilot.LocalizationChecks --configuration Release
+
       - name: Publish self-contained package
         run: dotnet publish src/EdgePilot/EdgePilot.csproj -c Release -r ${{ matrix.rid }} --self-contained true -p:DebugType=None -p:DebugSymbols=false -o dist/EdgePilot
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,38 @@
 # Changelog
 
-## 0.1.0-preview.1 — Unreleased
+## 0.2.0-preview.1 — Unreleased
 
-Initial public preview preparation.
+The v0.2 preview turns the initial system-monitor settings panel into a more coherent EdgePilot product surface and establishes localization as a first-class capability.
+
+### Added
+
+- Responsive Settings shell with dedicated Edge, Monitor, Behavior, Startup and About sections.
+- Interactive metric cards with contextual configuration; the disk-volume selector is hidden when Disk is disabled.
+- Italian, English and French interface localization with automatic system-language detection and a persisted manual override.
+- Localized tray, tooltips, installer/autostart messages, drive labels and metric captions.
+- Canonical SVG rendering inside Settings and About, while retaining a generated native ICO for Windows integration.
+- Product-focused About page with author attribution, GitHub repository/profile links and local-first principles.
+- Dedicated localization regression suite running on Windows and Ubuntu CI.
+
+### Changed
+
+- Settings code is split into shell/state, page composition and reusable controls to prepare for future modules such as Signals.
+- Settings save/reset state, labels, descriptions, icons and responsive behavior were redesigned without removing existing preferences.
+- Product positioning now describes EdgePilot as an edge-native desktop surface; the System monitor is the first module rather than the whole product.
+
+### Contributors
+
+- IT / EN / FR localization foundation contributed by [@IamArayel](https://github.com/IamArayel) in [PR #5](https://github.com/pricootz/edgepilot/pull/5), then reconciled with the v0.2 Settings redesign.
+
+## 0.1.0-preview.1
+
+Initial public preview foundation.
 
 - Local CPU, memory, disk and network monitoring on Windows and Linux.
 - Four-edge notch with rounded collapsed geometry, spring motion, reveal clipping, tooltips and pin/hover/fold behavior.
-- Italian settings with persistent display mode, metric visibility, refresh rate and hover sensitivity.
-- Persistent disk selection, including graceful handling of an unavailable volume.
+- Persistent display mode, metric visibility, refresh rate, hover sensitivity and disk selection.
 - Linux system theme integration for settings.
 - Tray menu, single-instance activation and optional start at login.
 - Self-contained x64 archives and per-user installation.
 - Windows/Ubuntu CI builds, headless UX regression checks and package launch/install checks.
-- English project documentation, Windows 11 screenshots and EdgePilot branding.
-
-Preview caveats and remaining validation are tracked in [the roadmap](docs/ROADMAP.md).
+- EdgePilot branding and canonical SVG asset workflow.

--- a/README.md
+++ b/README.md
@@ -3,49 +3,60 @@
 </p>
 
 <h1 align="center">EdgePilot</h1>
-<p align="center">Your system, one screen edge away.</p>
-<p align="center">A compact desktop system monitor for Windows and Linux.</p>
+<p align="center"><strong>Your desktop has edges. EdgePilot makes them useful.</strong></p>
+<p align="center">An edge-native desktop surface for Windows and Linux.</p>
 
 [![Build](https://github.com/pricootz/edgepilot/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/pricootz/edgepilot/actions/workflows/build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Early preview — v0.1.** EdgePilot unfolds from the edge of your screen to show local system activity. No account or server is required. The application interface is currently **Italian**; repository documentation is in English.
+**v0.2 preview.** EdgePilot lives at the edge of the desktop and stays out of the way until it is useful. The current System module surfaces live local machine activity; the project is evolving toward contextual signals and actions that appear only when they matter.
 
-## See it in action
+No account, server or telemetry uploader is required. The interface supports **Italian, English and French**, with automatic system-language detection or a manual override.
 
 <p align="center">
-  <img src="docs/assets/windows11-overview.png" width="520" alt="EdgePilot on Windows 11 with the complete settings window and expanded right-edge notch">
+  <img src="docs/assets/windows11-notch.png" width="150" alt="Expanded EdgePilot notch showing system metrics on Windows 11">
 </p>
-<p align="center">Windows 11 · Settings and expanded notch.</p>
+<p align="center">The current System module running from the screen edge.</p>
 
-<table>
-<tr><th>Settings</th><th>Expanded notch</th><th>Collapsed pill</th></tr>
-<tr>
-<td valign="top"><img src="docs/assets/windows11-settings.png" width="360" alt="Complete Windows 11 settings with disk selection and start at login"></td>
-<td valign="top"><img src="docs/assets/windows11-notch.png" width="136" alt="Expanded right-edge notch showing CPU, memory and disk usage on Windows 11"></td>
-<td valign="top"><img src="docs/assets/windows11-pill.png" width="48" alt="Compact collapsed pill attached to the right screen edge on Windows 11"></td>
-</tr>
-</table>
+## v0.2 at a glance
 
-These are real, unaltered Windows 11 screenshots supplied by the maintainer. The application interface is Italian; CPU, memory and disk are enabled in these captures. Ubuntu screenshots are still to come.
+- Redesigned responsive Settings experience with dedicated **Edge, Monitor, Behavior, Startup and About** sections.
+- Interactive metric cards and contextual options: disabling Disk also hides its volume selector.
+- IT / EN / FR localization across Settings, tray, tooltips, installer messages and persisted preferences.
+- Direct rendering of the canonical EdgePilot SVG in the app; Windows keeps a generated native ICO.
+- Clear product identity, author attribution and GitHub links in About.
+- Settings code split into shell, pages and reusable controls so future modules do not turn one window into a monolith.
+- Dedicated localization regression checks in addition to the existing Windows/Ubuntu UX and packaging CI.
 
 ## What works today
 
-- Live CPU and memory usage, disk capacity, network download/upload rates.
+- Live CPU and memory usage, disk capacity, and network download/upload rates.
 - Details for the network interface, uptime, host and operating system.
 - Rounded collapsed pill, spring motion, hover expansion, delayed folding and click-to-pin.
 - Placement on any of the four screen edges, with upright metric labels.
-- Persistent display modes, visible metrics, refresh interval and hover sensitivity.
-- Persistent disk selection by volume path; an unavailable disk is not silently replaced.
-- System light/dark theme in Linux settings, subject to desktop support.
+- Persistent display modes, visible metrics, refresh interval, hover sensitivity, language and disk selection.
+- Responsive Settings UI; Linux follows available system light/dark theme information.
 - Tray menu, optional start at login, per-user installation and single-instance activation.
-- Windows and Ubuntu CI builds, UX checks, packaged launch and installation checks.
+- Windows and Ubuntu CI builds, UX checks, localization checks, packaged launch and installation checks.
+- Local-first operation: no account, required cloud backend or telemetry uploader.
+
+## Next: Signals
+
+The next product step is **ambient Signals**: short-lived, context-aware events that temporarily take over the edge instead of behaving like traditional notifications.
+
+The first planned signals are intentionally small and reliable:
+
+- Internet connection lost / restored.
+- Low disk space.
+- Sustained unusual CPU activity.
+
+The design goal is simple: **you should not have to open EdgePilot to discover that something important happened.**
 
 ## Download and install
 
-Use the [Releases page](https://github.com/pricootz/edgepilot/releases) for published previews. **If it is empty, a release has not been published yet.**
+Use the [Releases page](https://github.com/pricootz/edgepilot/releases) for published previews. If it is empty, a release has not been published yet.
 
-For development builds, open a successful [build workflow](https://github.com/pricootz/edgepilot/actions/workflows/build.yml), then download **EdgePilot-win-x64** or **EdgePilot-linux-x64** under *Artifacts*. Artifact downloads require a GitHub sign-in and expire after 30 days. Unpack the artifact, then unpack the application archive inside it.
+For development builds, open a successful [build workflow](https://github.com/pricootz/edgepilot/actions/workflows/build.yml), then download **EdgePilot-win-x64** or **EdgePilot-linux-x64** under *Artifacts*. Artifact downloads require a GitHub sign-in and expire after 30 days.
 
 Packages include the .NET runtime; no SDK is needed. See the [installation guide](packaging/README.md) for running, installing, upgrading and removing EdgePilot.
 
@@ -59,30 +70,34 @@ cd edgepilot
 dotnet run --project src/EdgePilot/EdgePilot.csproj -c Release -- --settings
 ```
 
-Right-click the notch to open settings. **Applica** saves changes; **Esci** exits. Starting EdgePilot again opens the settings of the running instance.
+Right-click the notch or use the tray menu to open Settings. Changes remain pending until **Save changes** is pressed. Starting EdgePilot again activates the already-running instance instead of launching a duplicate.
 
-To build and run the executable regression suite:
+To build and run the regression suites:
 
 ```bash
 dotnet build src/EdgePilot/EdgePilot.csproj -c Release
 dotnet run --project tests/EdgePilot.UxChecks -c Release
+dotnet run --project tests/EdgePilot.LocalizationChecks -c Release
 ```
 
 ## Preview limitations
 
 - Current packages target **x64**. macOS, ARM packages and headless SSH sessions are not supported targets.
 - Linux transparency, positioning and tray visibility depend on the desktop/compositor. A GNOME AppIndicator extension may be needed.
-- Linux settings use Avalonia controls and system theme information, not native GTK/Yaru widgets.
-- Display scaling, multiple monitors and login behavior need broader real-desktop testing.
+- Display scaling, multiple monitors and login behavior still need broader real-desktop testing.
 - Disk selection follows a drive letter or mount path, not a hardware serial number.
 - Network interface selection is automatic. Temperatures, GPU and fan readings are not implemented.
 - Packages are unsigned and updates are manual. This is not yet a stable release.
 
 ## Privacy
 
-Metrics are sampled on the local computer. The app has no account, cloud backend or telemetry uploader. Settings are stored in the user's application-data folder. Screenshots and diagnostics may reveal hostnames, disk labels or paths: review them before attaching them to an issue.
+Metrics are sampled on the local computer. Settings are stored in the user's application-data folder. EdgePilot currently has no account, required cloud backend or telemetry uploader. Screenshots and diagnostics may reveal hostnames, disk labels or paths: review them before attaching them to an issue.
 
-## Documentation and contributing
+## Project and contributing
+
+EdgePilot is created and primarily maintained by [@pricootz](https://github.com/pricootz).
+
+The IT / EN / FR localization foundation was contributed by [@IamArayel](https://github.com/IamArayel) through [PR #5](https://github.com/pricootz/edgepilot/pull/5) and reconciled with the v0.2 Settings architecture.
 
 - [Settings](docs/SETTINGS.md) · [Desktop integration](docs/DESKTOP-INTEGRATION.md)
 - [Architecture](docs/ARCHITECTURE.md) · [Product scope](docs/PRODUCT.md) · [Roadmap](docs/ROADMAP.md)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap is directional, not a delivery schedule.
 
-## v0.1 preview — implemented
+## v0.1 foundation — implemented
 
 - [x] Local CPU, memory, disk, network and machine details.
 - [x] Four-edge notch, rounded pill, spring motion, clipping and tooltips.
@@ -14,25 +14,46 @@ This roadmap is directional, not a delivery schedule.
 - [x] Self-contained x64 packages and per-user installation.
 - [x] Windows/Ubuntu build, UX and package checks.
 
-## Before calling v0.1 stable
+## v0.2 product surface — implemented for preview
+
+- [x] Responsive Settings redesign with dedicated navigation and clearer hierarchy.
+- [x] Edge preview and direct edge/display controls.
+- [x] Interactive metric cards and conditional disk configuration.
+- [x] Canonical SVG branding inside the app and native Windows icon generation.
+- [x] Product-focused About page with author and GitHub links.
+- [x] Italian, English and French application localization.
+- [x] Automatic system-language detection plus persisted manual language selection.
+- [x] Localized tray, tooltip, installer and system-monitor strings.
+- [x] Split Settings implementation into shell, pages and reusable controls.
+- [x] Localization regression checks alongside existing UX/package CI.
+
+## Before promoting v0.2 beyond preview
 
 - [ ] Broader Windows 11 and Ubuntu desktop testing.
 - [ ] Verify real logout/login startup and tray behavior.
-- [ ] Confirm disk selection persists across restarts and mount changes.
-- [ ] Test all edges, scaling levels and monitor changes.
-- [ ] Check Ubuntu light/dark settings on supported sessions.
-- [x] Add current Windows 11 settings and expanded/collapsed notch screenshots.
-- [ ] Add Ubuntu screenshots.
-- [ ] Publish a preview release and gather feedback.
+- [ ] Test Settings at common scaling levels (100%, 125%, 150%) and smaller window sizes.
+- [ ] Validate all four edges and monitor changes on physical multi-monitor systems.
+- [ ] Confirm language switching and Automatic mode on Italian, English and French desktop locales.
+- [ ] Add current v0.2 Windows and Ubuntu screenshots.
+- [ ] Gather feedback from the preview release.
 
-## Next priorities
+## v0.3 direction — Signals / ambient awareness
 
-- Explicit network interface selection.
-- More useful CPU, memory and disk details.
-- Keyboard access, reduced motion and accessibility review.
-- English application localization.
-- Evaluate GPU/temperature/fan providers separately for each OS.
+The next major feature is a signal engine following the model **Observe → Decide → Surface → Act**. Signals should be temporary, deduplicated and context-aware rather than behaving like a traditional notification center.
+
+Initial scope:
+
+- Internet connection lost / restored.
+- Low disk space.
+- Sustained unusual CPU activity.
+
+Architecture direction:
+
+- Sensors / detectors publish normalized signals.
+- A signal service handles priority, deduplication, coalescing, rate limiting and expiry.
+- The edge temporarily morphs from its normal content into the active signal, then returns automatically.
+- Later signals may expose actions.
 
 ## Later exploration
 
-Remote monitoring, Docker and quick actions may become separate modules. No implementation or release date is promised.
+Potential modules include contextual actions, Edge Shelf / Smart Drop, Docker, Git, VPN/Tailscale, removable devices and richer system providers. These remain exploratory until the Signals foundation is proven.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,27 +1,50 @@
 # Settings
 
-Right-click the notch, choose **Impostazioni** in the tray menu, or start with --settings. A second launch opens settings in the running instance.
+Open Settings by right-clicking the notch, choosing **Settings / Impostazioni / Paramètres** from the tray menu, or launching EdgePilot with `--settings`. Starting EdgePilot a second time activates the Settings window of the running instance.
 
-| Italian label | Meaning |
-| --- | --- |
-| Bordo dello schermo | Right, left, top or bottom screen edge |
-| Visualizzazione | Hover, always open or hidden |
-| Metriche visibili | CPU, memory, disk and network; at least one is required |
-| Aggiornamento dei dati | 0.5, 1, 2 or 5 seconds |
-| Sensibilità di apertura | Precise, normal or wide activation area |
-| Disco da visualizzare | Automatic largest volume or an explicit volume path |
-| Avvia all’accesso | Optional current-user start at login |
-| Applica | Save and apply |
-| Esci | Exit EdgePilot |
+The v0.2 Settings experience is split into five sections.
 
-Apply saves atomically and updates the live panel. Closing without Apply discards edits. Visible metric count determines panel length; sampling remains available for hidden metrics. A refresh wait already in progress finishes before the new interval takes effect.
+## Edge
 
-Disk choices show labels, paths and decimal capacity. A missing explicit selection remains unavailable rather than switching to another disk. Mount paths are case-sensitive on Linux and case-insensitive on Windows.
+Controls where EdgePilot lives and how it appears.
 
-Preferences live in EdgePilot/settings.json under the user's application-data directory: %APPDATA% on Windows, normally ~/.config on Linux. Missing fields in older files retain defaults. Invalid files open settings with an explanation; failed saves leave active preferences unchanged.
+- **Position:** right, left, top or bottom edge, with a live visual preview.
+- **Panel behavior:** on hover, always visible or hidden.
 
-Tray show/hide is temporary. Apply persists the selected visibility mode. With no tray fallback, closing settings in hidden mode exits; otherwise the tray or a second launch provides recovery.
+## Monitor
 
-Linux settings follow the system theme information available to Avalonia. The notch retains its own dark styling. See [desktop integration](DESKTOP-INTEGRATION.md).
+Controls the current System module.
 
-For development, EDGEPILOT_EDGE can override the initial edge with right, left, top or bottom.
+- CPU, Memory, Disk and Network are interactive cards; at least one metric must remain enabled.
+- The notch resizes to the selected metric set.
+- The disk-volume selector is contextual: it is visible only while the Disk metric is enabled.
+- Explicit disk choices persist by volume path. If a selected volume disappears, EdgePilot reports it unavailable rather than silently switching to another disk.
+
+## Behavior
+
+- **Refresh frequency:** 0.5, 1, 2 or 5 seconds.
+- **Edge sensitivity:** precise, normal or wide activation area.
+- **Interface language:** Automatic (system), Italiano, English or Français.
+
+Automatic mode detects Italian and French explicitly and falls back to English for other system UI languages. Selecting a language manually persists the override. When the language changes, Settings reopens so the whole interface refreshes consistently.
+
+## Startup
+
+- Optional current-user start at login.
+- Explicit action to exit EdgePilot completely.
+
+## About
+
+Shows the EdgePilot product positioning, current version, local-first principles, project author and links to the GitHub repository and maintainer profile.
+
+## Saving and recovery
+
+Edits remain pending until **Save changes / Salva modifiche / Enregistrer** is pressed. The footer shows whether changes are pending and provides a reset action. Saving is atomic: a failed save does not replace the last valid preferences.
+
+Preferences live in `EdgePilot/settings.json` under the user's application-data directory: `%APPDATA%` on Windows and normally `~/.config` on Linux. Missing fields in older files retain defaults; invalid files open Settings with an explanation.
+
+Tray show/hide is temporary. Saving persists the selected visibility mode. With no tray fallback, closing Settings in hidden mode exits; otherwise the tray or a second launch provides recovery.
+
+Linux Settings follow system theme information available to Avalonia. The edge itself retains its dedicated EdgePilot visual language. See [desktop integration](DESKTOP-INTEGRATION.md).
+
+For development, `EDGEPILOT_EDGE` can override the initial edge with `right`, `left`, `top` or `bottom`.

--- a/src/EdgePilot/App.cs
+++ b/src/EdgePilot/App.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
+using EdgePilot.Core;
 using EdgePilot.UI;
 using EdgePilot.Platform;
 using Avalonia.Threading;
@@ -12,13 +13,13 @@ namespace EdgePilot;
 public sealed class App : Application
 {
     private TrayIcon? _tray;
+    private NativeMenuItem? _settingsMenuItem;
+    private NativeMenuItem? _toggleMenuItem;
+    private NativeMenuItem? _exitMenuItem;
+
     public override void Initialize()
     {
-        var italian = System.Globalization.CultureInfo.GetCultureInfo("it-IT");
-        System.Globalization.CultureInfo.DefaultThreadCurrentCulture = italian;
-        System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = italian;
-        System.Globalization.CultureInfo.CurrentCulture = italian;
-        System.Globalization.CultureInfo.CurrentUICulture = italian;
+        Localization.SetLanguage(Localization.DetectSystemLanguage());
         Styles.Add(new FluentTheme());
         RequestedThemeVariant = OperatingSystem.IsLinux() ? ThemeVariant.Default : ThemeVariant.Dark;
     }
@@ -36,8 +37,9 @@ public sealed class App : Application
             {
                 preferences = new();
                 System.Diagnostics.Trace.WriteLine(ex);
-                warning = "Impossibile leggere le impostazioni salvate. Sono attive quelle predefinite. Premi Applica per salvare nuovamente le preferenze.";
+                warning = Localization.T("warning.loadFailed");
             }
+            if (preferences.Language is { } language) Localization.SetLanguage(language);
             // Preserve the existing development override without writing it to disk.
             if (Environment.GetEnvironmentVariable("EDGEPILOT_EDGE") is { Length: > 0 })
                 preferences = preferences with { Edge = EdgePlacement.FromEnvironment() };
@@ -46,7 +48,7 @@ public sealed class App : Application
             catch (Exception ex) when (ex is System.IO.IOException or UnauthorizedAccessException or System.Security.SecurityException)
             {
                 System.Diagnostics.Trace.WriteLine(ex);
-                warning = "Non è stato possibile verificare l’avvio automatico. Controlla le impostazioni.";
+                warning = Localization.T("warning.autostartCheckFailed");
             }
             var window = new EdgeWindow();
             window.SavePreferences = value => DesktopPreferences.Save(PreferenceStore.DefaultPath,
@@ -55,16 +57,16 @@ public sealed class App : Application
             try
             {
                 var menu = new NativeMenu();
-                var settings = new NativeMenuItem { Header = "Impostazioni" };
-                settings.Click += (_, _) => window.ShowSettings();
-                var toggle = new NativeMenuItem { Header = "Mostra / Nascondi pannello" };
-                toggle.Click += (_, _) => window.ToggleVisibility();
-                var exit = new NativeMenuItem { Header = "Esci" };
-                exit.Click += (_, _) => desktop.Shutdown();
-                menu.Items.Add(settings);
-                menu.Items.Add(toggle);
+                _settingsMenuItem = new NativeMenuItem { Header = Localization.T("tray.settings") };
+                _settingsMenuItem.Click += (_, _) => window.ShowSettings();
+                _toggleMenuItem = new NativeMenuItem { Header = Localization.T("tray.toggle") };
+                _toggleMenuItem.Click += (_, _) => window.ToggleVisibility();
+                _exitMenuItem = new NativeMenuItem { Header = Localization.T("tray.exit") };
+                _exitMenuItem.Click += (_, _) => desktop.Shutdown();
+                menu.Items.Add(_settingsMenuItem);
+                menu.Items.Add(_toggleMenuItem);
                 menu.Items.Add(new NativeMenuItemSeparator());
-                menu.Items.Add(exit);
+                menu.Items.Add(_exitMenuItem);
                 _tray = new TrayIcon { Icon = AppIcon.Load(), ToolTipText = "EdgePilot", Menu = menu, IsVisible = true };
                 _tray.Clicked += (_, _) => window.ShowSettings();
                 TrayIcon.SetIcons(this, new TrayIcons { _tray });
@@ -76,8 +78,15 @@ public sealed class App : Application
                 _tray?.Dispose();
                 _tray = null;
                 window.HasTray = false;
-                warning = "Icona nell’area di notifica non disponibile. Puoi riaprire le impostazioni avviando nuovamente EdgePilot.";
+                warning = Localization.T("warning.trayUnavailable");
             }
+            window.PreferencesChanged += () =>
+            {
+                if (_settingsMenuItem is null) return;
+                _settingsMenuItem.Header = Localization.T("tray.settings");
+                _toggleMenuItem!.Header = Localization.T("tray.toggle");
+                _exitMenuItem!.Header = Localization.T("tray.exit");
+            };
             SingleInstance.Bind(() => Dispatcher.UIThread.Post(() => window.ShowSettings()));
             window.ApplyPreferences(preferences);
             desktop.MainWindow = window;

--- a/src/EdgePilot/Core/Language.cs
+++ b/src/EdgePilot/Core/Language.cs
@@ -1,0 +1,3 @@
+namespace EdgePilot.Core;
+
+public enum Language { Italian, English, French }

--- a/src/EdgePilot/Core/Localization.cs
+++ b/src/EdgePilot/Core/Localization.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace EdgePilot.Core;
+
+public static class Localization
+{
+    public static Language Current { get; private set; } = Language.English;
+
+    public static Language DetectSystemLanguage() => CultureInfo.InstalledUICulture.TwoLetterISOLanguageName switch
+    {
+        "it" => Language.Italian,
+        "fr" => Language.French,
+        _ => Language.English
+    };
+
+    public static void SetLanguage(Language language)
+    {
+        Current = language;
+        var culture = CultureInfo.GetCultureInfo(language switch
+        {
+            Language.Italian => "it-IT",
+            Language.French => "fr-FR",
+            _ => "en-US"
+        });
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+    }
+
+    public static string T(string key) => Strings.Catalog.TryGetValue(key, out var translations)
+        ? translations[Current]
+        : key;
+
+    public static string T(string key, params object?[] args) => string.Format(T(key), args);
+}

--- a/src/EdgePilot/Core/Localization.cs
+++ b/src/EdgePilot/Core/Localization.cs
@@ -6,12 +6,18 @@ public static class Localization
 {
     public static Language Current { get; private set; } = Language.English;
 
-    public static Language DetectSystemLanguage() => CultureInfo.InstalledUICulture.TwoLetterISOLanguageName switch
+    internal static Func<Language>? SystemLanguageDetectorOverride { get; set; }
+
+    public static Language DetectSystemLanguage()
     {
-        "it" => Language.Italian,
-        "fr" => Language.French,
-        _ => Language.English
-    };
+        if (SystemLanguageDetectorOverride is not null) return SystemLanguageDetectorOverride();
+        return CultureInfo.InstalledUICulture.TwoLetterISOLanguageName switch
+        {
+            "it" => Language.Italian,
+            "fr" => Language.French,
+            _ => Language.English
+        };
+    }
 
     public static void SetLanguage(Language language)
     {

--- a/src/EdgePilot/Core/Strings.cs
+++ b/src/EdgePilot/Core/Strings.cs
@@ -2,171 +2,298 @@ namespace EdgePilot.Core;
 
 internal static class Strings
 {
-    public static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<Language, string>> Catalog = new Dictionary<string, IReadOnlyDictionary<Language, string>>
-    {
-        // Tray menu
-        ["tray.settings"] = Map("Impostazioni", "Settings", "Paramètres"),
-        ["tray.toggle"] = Map("Mostra / Nascondi pannello", "Show / Hide panel", "Afficher / Masquer le panneau"),
-        ["tray.exit"] = Map("Esci", "Exit", "Quitter"),
+    public static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<Language, string>> Catalog =
+        new Dictionary<string, IReadOnlyDictionary<Language, string>>
+        {
+            // Tray menu
+            ["tray.settings"] = Map("Impostazioni", "Settings", "Paramètres"),
+            ["tray.toggle"] = Map("Mostra / Nascondi pannello", "Show / Hide panel", "Afficher / Masquer le panneau"),
+            ["tray.exit"] = Map("Esci", "Exit", "Quitter"),
 
-        // App-level warnings
-        ["warning.loadFailed"] = Map(
-            "Impossibile leggere le impostazioni salvate. Sono attive quelle predefinite. Premi Applica per salvare nuovamente le preferenze.",
-            "Unable to read saved settings. Defaults are active. Press Apply to save your preferences again.",
-            "Impossible de lire les paramètres enregistrés. Les valeurs par défaut sont actives. Appuyez sur Appliquer pour enregistrer à nouveau vos préférences."),
-        ["warning.autostartCheckFailed"] = Map(
-            "Non è stato possibile verificare l'avvio automatico. Controlla le impostazioni.",
-            "Could not verify startup-at-login status. Check settings.",
-            "Impossible de vérifier le démarrage automatique. Vérifiez les paramètres."),
-        ["warning.trayUnavailable"] = Map(
-            "Icona nell'area di notifica non disponibile. Puoi riaprire le impostazioni avviando nuovamente EdgePilot.",
-            "Tray icon unavailable. You can reopen settings by launching EdgePilot again.",
-            "Icône de la zone de notification indisponible. Vous pouvez rouvrir les paramètres en relançant EdgePilot."),
+            // App-level warnings
+            ["warning.loadFailed"] = Map(
+                "Impossibile leggere le impostazioni salvate. Sono attive quelle predefinite. Salva nuovamente le preferenze per ripristinare il file.",
+                "Unable to read saved settings. Defaults are active. Save your preferences again to restore the file.",
+                "Impossible de lire les paramètres enregistrés. Les valeurs par défaut sont actives. Enregistrez à nouveau vos préférences pour restaurer le fichier."),
+            ["warning.autostartCheckFailed"] = Map(
+                "Non è stato possibile verificare l'avvio automatico. Controlla le impostazioni.",
+                "Could not verify startup-at-login status. Check settings.",
+                "Impossible de vérifier le démarrage automatique. Vérifiez les paramètres."),
+            ["warning.trayUnavailable"] = Map(
+                "Icona nell'area di notifica non disponibile. Puoi riaprire le impostazioni avviando nuovamente EdgePilot.",
+                "Tray icon unavailable. You can reopen settings by launching EdgePilot again.",
+                "Icône de la zone de notification indisponible. Vous pouvez rouvrir les paramètres en relançant EdgePilot."),
 
-        // CLI (Program.cs)
-        ["cli.installedTo"] = Map("EdgePilot installato in {0}", "EdgePilot installed to {0}", "EdgePilot installé dans {0}"),
-        ["cli.installFailed"] = Map(
-            "Installazione non riuscita. Chiudi EdgePilot e riprova. {0}",
-            "Installation failed. Close EdgePilot and try again. {0}",
-            "Échec de l'installation. Fermez EdgePilot et réessayez. {0}"),
-        ["cli.alreadyRunning"] = Map(
-            "EdgePilot è già aperto ma non risponde. Chiudilo e riprova.",
-            "EdgePilot is already open but not responding. Close it and try again.",
-            "EdgePilot est déjà ouvert mais ne répond pas. Fermez-le et réessayez."),
+            // CLI
+            ["cli.installedTo"] = Map("EdgePilot installato in {0}", "EdgePilot installed to {0}", "EdgePilot installé dans {0}"),
+            ["cli.installFailed"] = Map(
+                "Installazione non riuscita. Chiudi EdgePilot e riprova. {0}",
+                "Installation failed. Close EdgePilot and try again. {0}",
+                "Échec de l'installation. Fermez EdgePilot et réessayez. {0}"),
+            ["cli.alreadyRunning"] = Map(
+                "EdgePilot è già aperto ma non risponde. Chiudilo e riprova.",
+                "EdgePilot is already open but not responding. Close it and try again.",
+                "EdgePilot est déjà ouvert mais ne répond pas. Fermez-le et réessayez."),
 
-        // Drive selection
-        ["drive.auto"] = Map("Automatico (disco più capiente)", "Automatic (largest disk)", "Automatique (disque le plus grand)"),
-        ["drive.unavailableSuffix"] = Map("{0} · non disponibile", "{0} · unavailable", "{0} · indisponible"),
+            // Drive selection
+            ["drive.auto"] = Map("Automatico (disco più capiente)", "Automatic (largest disk)", "Automatique (disque le plus grand)"),
+            ["drive.unavailableSuffix"] = Map("{0} · non disponibile", "{0} · unavailable", "{0} · indisponible"),
 
-        // Installer / autostart
-        ["installer.extractFirst"] = Map(
-            "Estrai il pacchetto in una cartella separata prima di installarlo.",
-            "Extract the package into a separate folder before installing it.",
-            "Extrayez le paquet dans un dossier séparé avant de l'installer."),
-        ["installer.startMenuUnavailable"] = Map("Menu Start non disponibile.", "Start menu unavailable.", "Menu Démarrer indisponible."),
-        ["desktop.comment"] = Map("Monitoraggio del sistema", "System monitoring", "Surveillance du système"),
-        ["autostart.pathUnavailable"] = Map("Percorso dell'app non disponibile.", "App path unavailable.", "Chemin de l'application indisponible."),
-        ["autostart.pathTooLong"] = Map(
-            "Percorso troppo lungo per l'avvio automatico di Windows.",
-            "Path too long for Windows startup registration.",
-            "Chemin trop long pour le démarrage automatique de Windows."),
-        ["autostart.invalidChars"] = Map(
-            "Il percorso dell'app contiene caratteri non supportati.",
-            "The app path contains unsupported characters.",
-            "Le chemin de l'application contient des caractères non pris en charge."),
-        ["autostart.updateFailed"] = Map(
-            "Impossibile aggiornare l'avvio automatico.",
-            "Unable to update startup-at-login registration.",
-            "Impossible de mettre à jour le démarrage automatique."),
-        ["appicon.unavailable"] = Map("Icona dell'app non disponibile.", "App icon unavailable.", "Icône de l'application indisponible."),
+            // Installer / autostart
+            ["installer.extractFirst"] = Map(
+                "Estrai il pacchetto in una cartella separata prima di installarlo.",
+                "Extract the package into a separate folder before installing it.",
+                "Extrayez le paquet dans un dossier séparé avant de l'installer."),
+            ["installer.startMenuUnavailable"] = Map("Menu Start non disponibile.", "Start menu unavailable.", "Menu Démarrer indisponible."),
+            ["desktop.comment"] = Map(
+                "Superficie desktop edge-native",
+                "Edge-native desktop surface",
+                "Surface de bureau native au bord de l'écran"),
+            ["autostart.pathUnavailable"] = Map("Percorso dell'app non disponibile.", "App path unavailable.", "Chemin de l'application indisponible."),
+            ["autostart.pathTooLong"] = Map(
+                "Percorso troppo lungo per l'avvio automatico di Windows.",
+                "Path too long for Windows startup registration.",
+                "Chemin trop long pour le démarrage automatique de Windows."),
+            ["autostart.invalidChars"] = Map(
+                "Il percorso dell'app contiene caratteri non supportati.",
+                "The app path contains unsupported characters.",
+                "Le chemin de l'application contient des caractères non pris en charge."),
+            ["autostart.updateFailed"] = Map(
+                "Impossibile aggiornare l'avvio automatico.",
+                "Unable to update startup-at-login registration.",
+                "Impossible de mettre à jour le démarrage automatique."),
+            ["appicon.unavailable"] = Map("Icona dell'app non disponibile.", "App icon unavailable.", "Icône de l'application indisponible."),
 
-        // Preferences validation (trace/log only, not shown to the user)
-        ["prefs.invalidEdgeMode"] = Map(
-            "Bordo o modalità di visualizzazione non supportati.",
-            "Unsupported edge or display mode.",
-            "Bord ou mode d'affichage non pris en charge."),
-        ["prefs.invalidRefresh"] = Map("Intervallo di aggiornamento non supportato.", "Unsupported refresh interval.", "Intervalle de rafraîchissement non pris en charge."),
-        ["prefs.invalidSensitivity"] = Map("Sensibilità non supportata.", "Unsupported sensitivity.", "Sensibilité non prise en charge."),
-        ["prefs.invalidMetrics"] = Map("Seleziona almeno una metrica valida.", "Select at least one valid metric.", "Sélectionnez au moins une métrique valide."),
-        ["prefs.invalidLanguage"] = Map("Lingua non supportata.", "Unsupported language.", "Langue non prise en charge."),
-        ["prefs.emptyFile"] = Map("Il file delle impostazioni è vuoto.", "The settings file is empty.", "Le fichier de paramètres est vide."),
+            // Preferences validation
+            ["prefs.invalidEdgeMode"] = Map(
+                "Bordo o modalità di visualizzazione non supportati.",
+                "Unsupported edge or display mode.",
+                "Bord ou mode d'affichage non pris en charge."),
+            ["prefs.invalidRefresh"] = Map("Intervallo di aggiornamento non supportato.", "Unsupported refresh interval.", "Intervalle de rafraîchissement non pris en charge."),
+            ["prefs.invalidSensitivity"] = Map("Sensibilità non supportata.", "Unsupported sensitivity.", "Sensibilité non prise en charge."),
+            ["prefs.invalidMetrics"] = Map("Seleziona almeno una metrica valida.", "Select at least one valid metric.", "Sélectionnez au moins une métrique valide."),
+            ["prefs.invalidLanguage"] = Map("Lingua non supportata.", "Unsupported language.", "Langue non prise en charge."),
+            ["prefs.emptyFile"] = Map("Il file delle impostazioni è vuoto.", "The settings file is empty.", "Le fichier de paramètres est vide."),
 
-        // Uptime unit
-        ["time.dayUnit"] = Map("g", "d", "j"),
+            // Time
+            ["time.dayUnit"] = Map("g", "d", "j"),
 
-        // Settings window
-        ["settings.title"] = Map("EdgePilot · Impostazioni", "EdgePilot · Settings", "EdgePilot · Paramètres"),
-        ["edge.right"] = Map("Destra", "Right", "Droite"),
-        ["edge.left"] = Map("Sinistra", "Left", "Gauche"),
-        ["edge.top"] = Map("Alto", "Top", "Haut"),
-        ["edge.bottom"] = Map("Basso", "Bottom", "Bas"),
-        ["mode.hover"] = Map("Al passaggio del mouse", "On hover", "Au survol"),
-        ["mode.always"] = Map("Sempre aperto", "Always open", "Toujours ouvert"),
-        ["mode.hidden"] = Map("Nascosto", "Hidden", "Masqué"),
-        ["refresh.0_5s"] = Map("Ogni 0,5 secondi", "Every 0.5 seconds", "Toutes les 0,5 secondes"),
-        ["refresh.1s"] = Map("Ogni secondo", "Every second", "Toutes les secondes"),
-        ["refresh.2s"] = Map("Ogni 2 secondi", "Every 2 seconds", "Toutes les 2 secondes"),
-        ["refresh.5s"] = Map("Ogni 5 secondi", "Every 5 seconds", "Toutes les 5 secondes"),
-        ["sensitivity.precise"] = Map("Precisa", "Precise", "Précise"),
-        ["sensitivity.normal"] = Map("Normale", "Normal", "Normale"),
-        ["sensitivity.wide"] = Map("Ampia", "Wide", "Large"),
-        ["metric.cpu"] = Map("CPU", "CPU", "CPU"),
-        ["metric.memory"] = Map("Memoria", "Memory", "Mémoire"),
-        ["metric.disk"] = Map("Disco", "Disk", "Disque"),
-        ["metric.network"] = Map("Rete", "Network", "Réseau"),
-        ["settings.autostart"] = Map("Avvia all'accesso", "Start at login", "Démarrer à la connexion"),
-        ["settings.exitButton"] = Map("Esci da EdgePilot", "Exit EdgePilot", "Quitter EdgePilot"),
-        ["settings.applyHint"] = Map("Premi Applica per salvare le modifiche.", "Press Apply to save your changes.", "Appuyez sur Appliquer pour enregistrer vos modifications."),
-        ["settings.apply"] = Map("Applica", "Apply", "Appliquer"),
-        ["settings.selectMetric"] = Map(
-            "Seleziona almeno una metrica da mostrare.",
-            "Select at least one metric to display.",
-            "Sélectionnez au moins une métrique à afficher."),
-        ["settings.hiddenWithTray"] = Map(
-            "Pannello nascosto. Usa l'icona nell'area di notifica per mostrarlo o riaprire le impostazioni.",
-            "Panel hidden. Use the tray icon to show it or reopen settings.",
-            "Panneau masqué. Utilisez l'icône de la zone de notification pour l'afficher ou rouvrir les paramètres."),
-        ["settings.hiddenNoTray"] = Map(
-            "Pannello nascosto. Scegli un'altra modalità per mostrarlo. Chiudendo le impostazioni esci da EdgePilot; al prossimo avvio tornerai qui.",
-            "Panel hidden. Choose a different mode to show it. Closing settings exits EdgePilot; you'll return here next time it starts.",
-            "Panneau masqué. Choisissez un autre mode pour l'afficher. Fermer les paramètres quitte EdgePilot ; vous reviendrez ici au prochain démarrage."),
-        ["settings.saved"] = Map(
-            "Impostazioni salvate. Fai clic destro sul pannello per riaprirle.",
-            "Settings saved. Right-click the panel to reopen them.",
-            "Paramètres enregistrés. Faites un clic droit sur le panneau pour les rouvrir."),
-        ["settings.saveFailed"] = Map(
-            "Impossibile salvare le impostazioni. Le preferenze attive non sono cambiate. Verifica i permessi di scrittura e lo spazio disponibile, poi riprova.",
-            "Unable to save settings. Your active preferences are unchanged. Check write permissions and available disk space, then try again.",
-            "Impossible d'enregistrer les paramètres. Vos préférences actives sont inchangées. Vérifiez les autorisations d'écriture et l'espace disponible, puis réessayez."),
-        ["settings.customize"] = Map("Personalizza EdgePilot", "Customize EdgePilot", "Personnaliser EdgePilot"),
-        ["settings.screenEdge"] = Map("Bordo dello schermo", "Screen edge", "Bord de l'écran"),
-        ["settings.displayMode"] = Map("Visualizzazione", "Display mode", "Mode d'affichage"),
-        ["settings.visibleMetrics"] = Map("Metriche visibili", "Visible metrics", "Métriques visibles"),
-        ["settings.dataRefresh"] = Map("Aggiornamento dei dati", "Data refresh", "Actualisation des données"),
-        ["settings.sensitivityLabel"] = Map("Sensibilità di apertura", "Opening sensitivity", "Sensibilité d'ouverture"),
-        ["settings.sensitivityHint"] = Map(
-            "Ampia: il pannello si apre anche passando vicino alla linguetta. Precisa: occorre avvicinarsi di più al bordo.",
-            "Wide: the panel opens even when passing near the tab. Precise: you need to get closer to the edge.",
-            "Large : le panneau s'ouvre même en passant près de l'onglet. Précise : il faut s'approcher davantage du bord."),
-        ["settings.driveLabel"] = Map("Disco da visualizzare", "Disk to display", "Disque à afficher"),
-        ["settings.driveHint"] = Map(
-            "Sono elencati i volumi montati e accessibili. Se manca un disco, montalo: l'elenco si aggiorna automaticamente.",
-            "Mounted, accessible volumes are listed. If a disk is missing, mount it: the list updates automatically.",
-            "Les volumes montés et accessibles sont listés. Si un disque manque, montez-le : la liste se met à jour automatiquement."),
-        ["settings.languageLabel"] = Map("Lingua", "Language", "Langue"),
-        ["language.auto"] = Map("Automatica (sistema)", "Automatic (system)", "Automatique (système)"),
+            // Common settings values
+            ["settings.title"] = Map("EdgePilot · Impostazioni", "EdgePilot · Settings", "EdgePilot · Paramètres"),
+            ["settings.headerSubtitle"] = Map("Impostazioni", "Settings", "Paramètres"),
+            ["settings.sidebarHeading"] = Map("IMPOSTAZIONI", "SETTINGS", "PARAMÈTRES"),
+            ["edge.right"] = Map("Destra", "Right", "Droite"),
+            ["edge.left"] = Map("Sinistra", "Left", "Gauche"),
+            ["edge.top"] = Map("Alto", "Top", "Haut"),
+            ["edge.bottom"] = Map("Basso", "Bottom", "Bas"),
+            ["mode.hover"] = Map("Al passaggio", "On hover", "Au survol"),
+            ["mode.always"] = Map("Sempre visibile", "Always visible", "Toujours visible"),
+            ["mode.hidden"] = Map("Nascosto", "Hidden", "Masqué"),
+            ["refresh.0_5s"] = Map("Ogni 0,5 secondi", "Every 0.5 seconds", "Toutes les 0,5 secondes"),
+            ["refresh.1s"] = Map("Ogni secondo", "Every second", "Toutes les secondes"),
+            ["refresh.2s"] = Map("Ogni 2 secondi", "Every 2 seconds", "Toutes les 2 secondes"),
+            ["refresh.5s"] = Map("Ogni 5 secondi", "Every 5 seconds", "Toutes les 5 secondes"),
+            ["sensitivity.precise"] = Map("Precisa", "Precise", "Précise"),
+            ["sensitivity.normal"] = Map("Normale", "Normal", "Normale"),
+            ["sensitivity.wide"] = Map("Ampia", "Wide", "Large"),
+            ["metric.cpu"] = Map("CPU", "CPU", "CPU"),
+            ["metric.memory"] = Map("Memoria", "Memory", "Mémoire"),
+            ["metric.disk"] = Map("Disco", "Disk", "Disque"),
+            ["metric.network"] = Map("Rete", "Network", "Réseau"),
+            ["language.auto"] = Map("Automatica (sistema)", "Automatic (system)", "Automatique (système)"),
 
-        // Notch tooltip / rings
-        ["ring.disk"] = Map("DISCO", "DISK", "DISQUE"),
-        ["ring.network"] = Map("RETE", "NETWORK", "RÉSEAU"),
-        ["tooltip.systemMonitoring"] = Map("MONITORAGGIO SISTEMA", "SYSTEM MONITORING", "SURVEILLANCE SYSTÈME"),
-        ["tooltip.error"] = Map("ERRORE", "ERROR", "ERREUR"),
-        ["tooltip.updateFailed"] = Map("Impossibile aggiornare i dati del sistema.", "Unable to refresh system data.", "Impossible d'actualiser les données système."),
-        ["tooltip.retryNext"] = Map("Nuovo tentativo al prossimo aggiornamento.", "Will retry on the next update.", "Nouvelle tentative à la prochaine mise à jour."),
-        ["network.yes"] = Map("SÌ", "YES", "OUI"),
-        ["network.no"] = Map("NO", "NO", "NON"),
-        ["tooltip.processors"] = Map("{0} processori logici", "{0} logical processors", "{0} processeurs logiques"),
-        ["tooltip.memory"] = Map("MEMORIA", "MEMORY", "MÉMOIRE"),
-        ["bytes.used"] = Map("{0} utilizzati", "{0} used", "{0} utilisés"),
-        ["bytes.available"] = Map("{0} disponibili", "{0} available", "{0} disponibles"),
-        ["bytes.total"] = Map("{0} totali", "{0} total", "{0} au total"),
-        ["tooltip.storage"] = Map("ARCHIVIAZIONE", "STORAGE", "STOCKAGE"),
-        ["storage.noDisk"] = Map("Nessun disco disponibile", "No disk available", "Aucun disque disponible"),
-        ["storage.unavailable"] = Map("Il disco scelto non è disponibile", "Selected disk unavailable", "Disque sélectionné indisponible"),
-        ["storage.chooseInSettings"] = Map("Scegli il disco nelle impostazioni.", "Choose the disk in settings.", "Choisissez le disque dans les paramètres."),
-        ["bytes.free"] = Map("{0} liberi", "{0} free", "{0} libres"),
-        ["tooltip.network"] = Map("RETE", "NETWORK", "RÉSEAU"),
-        ["network.connected"] = Map("CONNESSA", "CONNECTED", "CONNECTÉ"),
-        ["network.disconnected"] = Map("DISCONNESSA", "DISCONNECTED", "DÉCONNECTÉ"),
-        ["network.noInterface"] = Map("Nessuna interfaccia di rete attiva", "No active network interface", "Aucune interface réseau active"),
-        ["network.linkSpeed"] = Map("Velocità collegamento: {0} Mbps", "Link speed: {0} Mbps", "Vitesse de liaison : {0} Mbps"),
-        ["network.uptime"] = Map("Tempo di attività: {0}", "Uptime: {0}", "Disponibilité : {0}"),
-    };
+            // Navigation
+            ["nav.edge"] = Map("Bordo", "Edge", "Bord"),
+            ["nav.monitor"] = Map("Monitor", "Monitor", "Moniteur"),
+            ["nav.behavior"] = Map("Comportamento", "Behavior", "Comportement"),
+            ["nav.startup"] = Map("Avvio", "Startup", "Démarrage"),
+            ["nav.about"] = Map("Informazioni", "About", "À propos"),
 
-    private static IReadOnlyDictionary<Language, string> Map(string italian, string english, string french) => new Dictionary<Language, string>
-    {
-        [Language.Italian] = italian,
-        [Language.English] = english,
-        [Language.French] = french,
-    };
+            // Footer / save state
+            ["settings.status.saved"] = Map("Tutto salvato.", "Everything is saved.", "Tout est enregistré."),
+            ["settings.status.unsaved"] = Map("Modifiche non salvate.", "Unsaved changes.", "Modifications non enregistrées."),
+            ["settings.status.reset"] = Map("Modifiche annullate.", "Changes reverted.", "Modifications annulées."),
+            ["settings.saveChanges"] = Map("Salva modifiche", "Save changes", "Enregistrer"),
+            ["settings.resetChanges"] = Map("Annulla", "Reset", "Annuler"),
+            ["settings.selectMetric"] = Map(
+                "Seleziona almeno una metrica da mostrare.",
+                "Select at least one metric to display.",
+                "Sélectionnez au moins une métrique à afficher."),
+            ["settings.hiddenWithTray"] = Map(
+                "Pannello nascosto. Puoi riaprirlo dall'area di notifica.",
+                "Panel hidden. You can reopen it from the tray icon.",
+                "Panneau masqué. Vous pouvez le rouvrir depuis l'icône de la zone de notification."),
+            ["settings.hiddenNoTray"] = Map(
+                "Pannello nascosto. Chiudendo le impostazioni esci da EdgePilot; al prossimo avvio tornerai qui.",
+                "Panel hidden. Closing settings exits EdgePilot; you will return here on the next launch.",
+                "Panneau masqué. Fermer les paramètres quitte EdgePilot ; vous reviendrez ici au prochain lancement."),
+            ["settings.saved"] = Map("Impostazioni salvate.", "Settings saved.", "Paramètres enregistrés."),
+            ["settings.saveFailed"] = Map(
+                "Impossibile salvare le impostazioni. Verifica permessi e spazio disponibile, poi riprova.",
+                "Unable to save settings. Check permissions and available disk space, then try again.",
+                "Impossible d'enregistrer les paramètres. Vérifiez les autorisations et l'espace disponible, puis réessayez."),
+            ["settings.browserFailed"] = Map(
+                "Impossibile aprire il browser. Visita github.com/pricootz/edgepilot.",
+                "Unable to open the browser. Visit github.com/pricootz/edgepilot.",
+                "Impossible d'ouvrir le navigateur. Visitez github.com/pricootz/edgepilot."),
+
+            // Edge page
+            ["edge.pageTitle"] = Map("Bordo e presenza", "Edge & presence", "Bord et présence"),
+            ["edge.pageSubtitle"] = Map(
+                "Definisci dove vive EdgePilot e quanto deve essere presente sul desktop.",
+                "Choose where EdgePilot lives and how present it should be on your desktop.",
+                "Définissez où vit EdgePilot et à quel point il doit être présent sur votre bureau."),
+            ["edge.positionTitle"] = Map("Posizione sullo schermo", "Screen position", "Position à l'écran"),
+            ["edge.positionDescription"] = Map(
+                "La preview cambia insieme alla scelta e mostra dove comparirà la linguetta.",
+                "The preview follows your selection and shows where the tab will appear.",
+                "L'aperçu suit votre choix et montre où l'onglet apparaîtra."),
+            ["edge.positionLabel"] = Map("Posizione", "Position", "Position"),
+            ["edge.positionHint"] = Map("Scegli il bordo da cui EdgePilot deve emergere.", "Choose the edge EdgePilot should emerge from.", "Choisissez le bord depuis lequel EdgePilot doit apparaître."),
+            ["edge.behaviorTitle"] = Map("Comportamento del pannello", "Panel behavior", "Comportement du panneau"),
+            ["edge.behaviorDescription"] = Map(
+                "Al passaggio mantiene EdgePilot discreto. Sempre visibile lo lascia aperto. Nascosto lo rimuove dal bordo finché non lo riapri dalla tray o dalle impostazioni.",
+                "On hover keeps EdgePilot discreet. Always visible keeps it open. Hidden removes it from the edge until you reopen it from the tray or settings.",
+                "Au survol garde EdgePilot discret. Toujours visible le maintient ouvert. Masqué le retire du bord jusqu'à sa réouverture depuis la zone de notification ou les paramètres."),
+
+            // Monitor page
+            ["monitor.pageTitle"] = Map("Monitor di sistema", "System monitor", "Moniteur système"),
+            ["monitor.pageSubtitle"] = Map(
+                "Decidi quali dati del modulo System devono comparire nella notch.",
+                "Choose which System module data should appear in the notch.",
+                "Choisissez les données du module Système à afficher dans l'encoche."),
+            ["monitor.metricsTitle"] = Map("Metriche visibili", "Visible metrics", "Métriques visibles"),
+            ["monitor.metricsDescription"] = Map(
+                "Fai clic sull'intera scheda per attivare o disattivare una metrica. La notch si ridimensiona automaticamente.",
+                "Click the whole card to enable or disable a metric. The notch resizes automatically.",
+                "Cliquez sur toute la carte pour activer ou désactiver une métrique. L'encoche se redimensionne automatiquement."),
+            ["metric.cpu.description"] = Map("Carico del processore in tempo reale", "Real-time processor load", "Charge du processeur en temps réel"),
+            ["metric.memory.description"] = Map("Memoria RAM attualmente utilizzata", "Current RAM usage", "Mémoire RAM actuellement utilisée"),
+            ["metric.disk.description"] = Map("Spazio occupato sul volume scelto", "Used space on the selected volume", "Espace utilisé sur le volume sélectionné"),
+            ["metric.network.description"] = Map("Traffico di download e upload", "Download and upload traffic", "Trafic de téléchargement et d'envoi"),
+            ["monitor.diskTitle"] = Map("Volume per la metrica Disco", "Volume for the Disk metric", "Volume pour la métrique Disque"),
+            ["monitor.diskDescription"] = Map(
+                "Questa scelta compare solo quando la metrica Disco è attiva. EdgePilot conserva comunque la selezione se la disattivi temporaneamente.",
+                "This option appears only while the Disk metric is enabled. EdgePilot still keeps your selection if you temporarily disable it.",
+                "Cette option apparaît uniquement lorsque la métrique Disque est active. EdgePilot conserve votre sélection si vous la désactivez temporairement."),
+
+            // Behavior page
+            ["behavior.pageTitle"] = Map("Comportamento", "Behavior", "Comportement"),
+            ["behavior.pageSubtitle"] = Map(
+                "Regola quanto spesso EdgePilot aggiorna i dati, quanto facilmente reagisce al bordo e la lingua dell'interfaccia.",
+                "Control how often EdgePilot refreshes data, how easily it reacts to the edge, and the interface language.",
+                "Réglez la fréquence d'actualisation, la sensibilité au bord et la langue de l'interface."),
+            ["behavior.refreshTitle"] = Map("Frequenza di aggiornamento", "Refresh frequency", "Fréquence d'actualisation"),
+            ["behavior.refreshDescription"] = Map(
+                "Un intervallo breve rende i valori più reattivi. Un intervallo più lungo riduce leggermente il lavoro in background.",
+                "A shorter interval makes values more responsive. A longer interval slightly reduces background work.",
+                "Un intervalle court rend les valeurs plus réactives. Un intervalle plus long réduit légèrement le travail en arrière-plan."),
+            ["behavior.refreshLabel"] = Map("Aggiorna i dati", "Refresh data", "Actualiser les données"),
+            ["behavior.sensitivityTitle"] = Map("Sensibilità al bordo", "Edge sensitivity", "Sensibilité au bord"),
+            ["behavior.sensitivityDescription"] = Map(
+                "Precisa richiede di arrivare vicino alla linguetta. Ampia crea una zona di aggancio più generosa. Normale è il compromesso consigliato.",
+                "Precise requires getting close to the tab. Wide creates a larger activation zone. Normal is the recommended balance.",
+                "Précise exige de s'approcher de l'onglet. Large crée une zone d'activation plus généreuse. Normale est le compromis recommandé."),
+            ["behavior.languageTitle"] = Map("Lingua dell'interfaccia", "Interface language", "Langue de l'interface"),
+            ["behavior.languageDescription"] = Map(
+                "Automatica segue la lingua del sistema quando disponibile. Puoi forzare Italiano, English o Français.",
+                "Automatic follows the system language when available. You can force Italiano, English, or Français.",
+                "Automatique suit la langue du système lorsqu'elle est disponible. Vous pouvez forcer Italiano, English ou Français."),
+
+            // Startup page
+            ["startup.pageTitle"] = Map("Avvio e sessione", "Startup & session", "Démarrage et session"),
+            ["startup.pageSubtitle"] = Map(
+                "Scegli come EdgePilot entra nella sessione e quando deve terminare completamente.",
+                "Choose how EdgePilot enters your session and when it should shut down completely.",
+                "Choisissez comment EdgePilot démarre dans votre session et quand il doit se fermer complètement."),
+            ["startup.autostartTitle"] = Map("Avvio automatico", "Start at login", "Démarrage automatique"),
+            ["startup.autostartDescription"] = Map(
+                "Abilita l'avvio per l'utente corrente. EdgePilot resterà disponibile senza doverlo lanciare manualmente a ogni accesso.",
+                "Enable startup for the current user. EdgePilot will remain available without being launched manually after every sign-in.",
+                "Activez le démarrage pour l'utilisateur actuel. EdgePilot restera disponible sans lancement manuel à chaque connexion."),
+            ["startup.autostartLabel"] = Map(
+                "Avvia EdgePilot quando accedo al sistema",
+                "Start EdgePilot when I sign in",
+                "Démarrer EdgePilot à ma connexion"),
+            ["startup.sessionTitle"] = Map("Sessione corrente", "Current session", "Session actuelle"),
+            ["startup.sessionDescription"] = Map(
+                "Chiude completamente EdgePilot, inclusi pannello e processo in background.",
+                "Completely closes EdgePilot, including the panel and background process.",
+                "Ferme complètement EdgePilot, y compris le panneau et le processus en arrière-plan."),
+            ["startup.exitButton"] = Map("Esci da EdgePilot", "Exit EdgePilot", "Quitter EdgePilot"),
+
+            // About page
+            ["about.pageTitle"] = Map("Informazioni", "About", "À propos"),
+            ["about.pageSubtitle"] = Map(
+                "Il progetto, chi lo sviluppa e i principi su cui viene costruito.",
+                "The project, who builds it, and the principles behind it.",
+                "Le projet, son auteur et les principes sur lesquels il est construit."),
+            ["about.productDescription"] = Map(
+                "Una superficie desktop edge-native per Windows e Linux, progettata per mostrare informazioni e azioni solo quando servono.",
+                "An edge-native desktop surface for Windows and Linux, designed to surface information and actions only when they matter.",
+                "Une surface de bureau native au bord de l'écran pour Windows et Linux, conçue pour afficher informations et actions uniquement lorsqu'elles comptent."),
+            ["about.authorTitle"] = Map("Autore", "Author", "Auteur"),
+            ["about.authorLine"] = Map("Creato e mantenuto da @pricootz", "Created and maintained by @pricootz", "Créé et maintenu par @pricootz"),
+            ["about.authorDescription"] = Map(
+                "EdgePilot è un progetto indipendente open source. Idee, sviluppo, direzione del prodotto e manutenzione principale fanno capo a @pricootz, con contributi della community tramite GitHub.",
+                "EdgePilot is an independent open-source project. Product direction, development, and primary maintenance are led by @pricootz, with community contributions through GitHub.",
+                "EdgePilot est un projet open source indépendant. La direction du produit, le développement et la maintenance principale sont assurés par @pricootz, avec des contributions de la communauté via GitHub."),
+            ["about.repoButton"] = Map("Repository GitHub", "GitHub repository", "Dépôt GitHub"),
+            ["about.profileButton"] = Map("Profilo @pricootz", "@pricootz profile", "Profil @pricootz"),
+            ["about.philosophyTitle"] = Map("Filosofia del progetto", "Project philosophy", "Philosophie du projet"),
+            ["about.localTitle"] = Map("Locale per impostazione predefinita", "Local by default", "Local par défaut"),
+            ["about.localDescription"] = Map(
+                "Nessun account, nessun backend cloud obbligatorio e nessun uploader di telemetria.",
+                "No account, no required cloud backend, and no telemetry uploader.",
+                "Aucun compte, aucun backend cloud obligatoire et aucun envoi de télémétrie."),
+            ["about.edgeNativeTitle"] = Map("Edge-native", "Edge-native", "Edge-native"),
+            ["about.edgeNativeDescription"] = Map(
+                "EdgePilot vive sul bordo dello schermo e punta a ridurre finestre, dashboard e notifiche tradizionali.",
+                "EdgePilot lives on the screen edge and aims to reduce traditional windows, dashboards, and notifications.",
+                "EdgePilot vit au bord de l'écran et vise à réduire les fenêtres, tableaux de bord et notifications traditionnels."),
+            ["about.evolvingTitle"] = Map("In evoluzione", "Evolving", "En évolution"),
+            ["about.evolvingDescription"] = Map(
+                "La preview attuale parte dal monitor di sistema; i prossimi moduli allargheranno il concetto senza trasformarlo in un pannello generico.",
+                "The current preview starts with system monitoring; upcoming modules will expand the idea without turning it into a generic dashboard.",
+                "La version actuelle commence par le monitoring système ; les prochains modules élargiront le concept sans en faire un tableau de bord générique."),
+            ["about.versionTitle"] = Map("Versione", "Version", "Version"),
+            ["about.versionDescription"] = Map(
+                "Preview in sviluppo attivo. Le API, il layout e alcune funzioni possono ancora cambiare prima della prima release stabile.",
+                "Preview under active development. APIs, layout, and some features may still change before the first stable release.",
+                "Preview en développement actif. Les API, la mise en page et certaines fonctions peuvent encore changer avant la première version stable."),
+
+            // Notch tooltip / rings
+            ["ring.disk"] = Map("DISCO", "DISK", "DISQUE"),
+            ["ring.network"] = Map("RETE", "NETWORK", "RÉSEAU"),
+            ["tooltip.systemMonitoring"] = Map("MONITORAGGIO SISTEMA", "SYSTEM MONITORING", "SURVEILLANCE SYSTÈME"),
+            ["tooltip.error"] = Map("ERRORE", "ERROR", "ERREUR"),
+            ["tooltip.updateFailed"] = Map("Impossibile aggiornare i dati del sistema.", "Unable to refresh system data.", "Impossible d'actualiser les données système."),
+            ["tooltip.retryNext"] = Map("Nuovo tentativo al prossimo aggiornamento.", "Will retry on the next update.", "Nouvelle tentative à la prochaine mise à jour."),
+            ["network.yes"] = Map("SÌ", "YES", "OUI"),
+            ["network.no"] = Map("NO", "NO", "NON"),
+            ["tooltip.processors"] = Map("{0} processori logici", "{0} logical processors", "{0} processeurs logiques"),
+            ["tooltip.memory"] = Map("MEMORIA", "MEMORY", "MÉMOIRE"),
+            ["bytes.used"] = Map("{0} utilizzati", "{0} used", "{0} utilisés"),
+            ["bytes.available"] = Map("{0} disponibili", "{0} available", "{0} disponibles"),
+            ["bytes.total"] = Map("{0} totali", "{0} total", "{0} au total"),
+            ["tooltip.storage"] = Map("ARCHIVIAZIONE", "STORAGE", "STOCKAGE"),
+            ["storage.noDisk"] = Map("Nessun disco disponibile", "No disk available", "Aucun disque disponible"),
+            ["storage.unavailable"] = Map("Il disco scelto non è disponibile", "Selected disk unavailable", "Disque sélectionné indisponible"),
+            ["storage.chooseInSettings"] = Map("Scegli il disco nelle impostazioni.", "Choose the disk in settings.", "Choisissez le disque dans les paramètres."),
+            ["bytes.free"] = Map("{0} liberi", "{0} free", "{0} libres"),
+            ["tooltip.network"] = Map("RETE", "NETWORK", "RÉSEAU"),
+            ["network.connected"] = Map("CONNESSA", "CONNECTED", "CONNECTÉ"),
+            ["network.disconnected"] = Map("DISCONNESSA", "DISCONNECTED", "DÉCONNECTÉ"),
+            ["network.noInterface"] = Map("Nessuna interfaccia di rete attiva", "No active network interface", "Aucune interface réseau active"),
+            ["network.linkSpeed"] = Map("Velocità collegamento: {0} Mbps", "Link speed: {0} Mbps", "Vitesse de liaison : {0} Mbps"),
+            ["network.uptime"] = Map("Tempo di attività: {0}", "Uptime: {0}", "Disponibilité : {0}"),
+        };
+
+    private static IReadOnlyDictionary<Language, string> Map(string italian, string english, string french) =>
+        new Dictionary<Language, string>
+        {
+            [Language.Italian] = italian,
+            [Language.English] = english,
+            [Language.French] = french,
+        };
 }

--- a/src/EdgePilot/Core/Strings.cs
+++ b/src/EdgePilot/Core/Strings.cs
@@ -1,0 +1,172 @@
+namespace EdgePilot.Core;
+
+internal static class Strings
+{
+    public static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<Language, string>> Catalog = new Dictionary<string, IReadOnlyDictionary<Language, string>>
+    {
+        // Tray menu
+        ["tray.settings"] = Map("Impostazioni", "Settings", "Paramètres"),
+        ["tray.toggle"] = Map("Mostra / Nascondi pannello", "Show / Hide panel", "Afficher / Masquer le panneau"),
+        ["tray.exit"] = Map("Esci", "Exit", "Quitter"),
+
+        // App-level warnings
+        ["warning.loadFailed"] = Map(
+            "Impossibile leggere le impostazioni salvate. Sono attive quelle predefinite. Premi Applica per salvare nuovamente le preferenze.",
+            "Unable to read saved settings. Defaults are active. Press Apply to save your preferences again.",
+            "Impossible de lire les paramètres enregistrés. Les valeurs par défaut sont actives. Appuyez sur Appliquer pour enregistrer à nouveau vos préférences."),
+        ["warning.autostartCheckFailed"] = Map(
+            "Non è stato possibile verificare l'avvio automatico. Controlla le impostazioni.",
+            "Could not verify startup-at-login status. Check settings.",
+            "Impossible de vérifier le démarrage automatique. Vérifiez les paramètres."),
+        ["warning.trayUnavailable"] = Map(
+            "Icona nell'area di notifica non disponibile. Puoi riaprire le impostazioni avviando nuovamente EdgePilot.",
+            "Tray icon unavailable. You can reopen settings by launching EdgePilot again.",
+            "Icône de la zone de notification indisponible. Vous pouvez rouvrir les paramètres en relançant EdgePilot."),
+
+        // CLI (Program.cs)
+        ["cli.installedTo"] = Map("EdgePilot installato in {0}", "EdgePilot installed to {0}", "EdgePilot installé dans {0}"),
+        ["cli.installFailed"] = Map(
+            "Installazione non riuscita. Chiudi EdgePilot e riprova. {0}",
+            "Installation failed. Close EdgePilot and try again. {0}",
+            "Échec de l'installation. Fermez EdgePilot et réessayez. {0}"),
+        ["cli.alreadyRunning"] = Map(
+            "EdgePilot è già aperto ma non risponde. Chiudilo e riprova.",
+            "EdgePilot is already open but not responding. Close it and try again.",
+            "EdgePilot est déjà ouvert mais ne répond pas. Fermez-le et réessayez."),
+
+        // Drive selection
+        ["drive.auto"] = Map("Automatico (disco più capiente)", "Automatic (largest disk)", "Automatique (disque le plus grand)"),
+        ["drive.unavailableSuffix"] = Map("{0} · non disponibile", "{0} · unavailable", "{0} · indisponible"),
+
+        // Installer / autostart
+        ["installer.extractFirst"] = Map(
+            "Estrai il pacchetto in una cartella separata prima di installarlo.",
+            "Extract the package into a separate folder before installing it.",
+            "Extrayez le paquet dans un dossier séparé avant de l'installer."),
+        ["installer.startMenuUnavailable"] = Map("Menu Start non disponibile.", "Start menu unavailable.", "Menu Démarrer indisponible."),
+        ["desktop.comment"] = Map("Monitoraggio del sistema", "System monitoring", "Surveillance du système"),
+        ["autostart.pathUnavailable"] = Map("Percorso dell'app non disponibile.", "App path unavailable.", "Chemin de l'application indisponible."),
+        ["autostart.pathTooLong"] = Map(
+            "Percorso troppo lungo per l'avvio automatico di Windows.",
+            "Path too long for Windows startup registration.",
+            "Chemin trop long pour le démarrage automatique de Windows."),
+        ["autostart.invalidChars"] = Map(
+            "Il percorso dell'app contiene caratteri non supportati.",
+            "The app path contains unsupported characters.",
+            "Le chemin de l'application contient des caractères non pris en charge."),
+        ["autostart.updateFailed"] = Map(
+            "Impossibile aggiornare l'avvio automatico.",
+            "Unable to update startup-at-login registration.",
+            "Impossible de mettre à jour le démarrage automatique."),
+        ["appicon.unavailable"] = Map("Icona dell'app non disponibile.", "App icon unavailable.", "Icône de l'application indisponible."),
+
+        // Preferences validation (trace/log only, not shown to the user)
+        ["prefs.invalidEdgeMode"] = Map(
+            "Bordo o modalità di visualizzazione non supportati.",
+            "Unsupported edge or display mode.",
+            "Bord ou mode d'affichage non pris en charge."),
+        ["prefs.invalidRefresh"] = Map("Intervallo di aggiornamento non supportato.", "Unsupported refresh interval.", "Intervalle de rafraîchissement non pris en charge."),
+        ["prefs.invalidSensitivity"] = Map("Sensibilità non supportata.", "Unsupported sensitivity.", "Sensibilité non prise en charge."),
+        ["prefs.invalidMetrics"] = Map("Seleziona almeno una metrica valida.", "Select at least one valid metric.", "Sélectionnez au moins une métrique valide."),
+        ["prefs.invalidLanguage"] = Map("Lingua non supportata.", "Unsupported language.", "Langue non prise en charge."),
+        ["prefs.emptyFile"] = Map("Il file delle impostazioni è vuoto.", "The settings file is empty.", "Le fichier de paramètres est vide."),
+
+        // Uptime unit
+        ["time.dayUnit"] = Map("g", "d", "j"),
+
+        // Settings window
+        ["settings.title"] = Map("EdgePilot · Impostazioni", "EdgePilot · Settings", "EdgePilot · Paramètres"),
+        ["edge.right"] = Map("Destra", "Right", "Droite"),
+        ["edge.left"] = Map("Sinistra", "Left", "Gauche"),
+        ["edge.top"] = Map("Alto", "Top", "Haut"),
+        ["edge.bottom"] = Map("Basso", "Bottom", "Bas"),
+        ["mode.hover"] = Map("Al passaggio del mouse", "On hover", "Au survol"),
+        ["mode.always"] = Map("Sempre aperto", "Always open", "Toujours ouvert"),
+        ["mode.hidden"] = Map("Nascosto", "Hidden", "Masqué"),
+        ["refresh.0_5s"] = Map("Ogni 0,5 secondi", "Every 0.5 seconds", "Toutes les 0,5 secondes"),
+        ["refresh.1s"] = Map("Ogni secondo", "Every second", "Toutes les secondes"),
+        ["refresh.2s"] = Map("Ogni 2 secondi", "Every 2 seconds", "Toutes les 2 secondes"),
+        ["refresh.5s"] = Map("Ogni 5 secondi", "Every 5 seconds", "Toutes les 5 secondes"),
+        ["sensitivity.precise"] = Map("Precisa", "Precise", "Précise"),
+        ["sensitivity.normal"] = Map("Normale", "Normal", "Normale"),
+        ["sensitivity.wide"] = Map("Ampia", "Wide", "Large"),
+        ["metric.cpu"] = Map("CPU", "CPU", "CPU"),
+        ["metric.memory"] = Map("Memoria", "Memory", "Mémoire"),
+        ["metric.disk"] = Map("Disco", "Disk", "Disque"),
+        ["metric.network"] = Map("Rete", "Network", "Réseau"),
+        ["settings.autostart"] = Map("Avvia all'accesso", "Start at login", "Démarrer à la connexion"),
+        ["settings.exitButton"] = Map("Esci da EdgePilot", "Exit EdgePilot", "Quitter EdgePilot"),
+        ["settings.applyHint"] = Map("Premi Applica per salvare le modifiche.", "Press Apply to save your changes.", "Appuyez sur Appliquer pour enregistrer vos modifications."),
+        ["settings.apply"] = Map("Applica", "Apply", "Appliquer"),
+        ["settings.selectMetric"] = Map(
+            "Seleziona almeno una metrica da mostrare.",
+            "Select at least one metric to display.",
+            "Sélectionnez au moins une métrique à afficher."),
+        ["settings.hiddenWithTray"] = Map(
+            "Pannello nascosto. Usa l'icona nell'area di notifica per mostrarlo o riaprire le impostazioni.",
+            "Panel hidden. Use the tray icon to show it or reopen settings.",
+            "Panneau masqué. Utilisez l'icône de la zone de notification pour l'afficher ou rouvrir les paramètres."),
+        ["settings.hiddenNoTray"] = Map(
+            "Pannello nascosto. Scegli un'altra modalità per mostrarlo. Chiudendo le impostazioni esci da EdgePilot; al prossimo avvio tornerai qui.",
+            "Panel hidden. Choose a different mode to show it. Closing settings exits EdgePilot; you'll return here next time it starts.",
+            "Panneau masqué. Choisissez un autre mode pour l'afficher. Fermer les paramètres quitte EdgePilot ; vous reviendrez ici au prochain démarrage."),
+        ["settings.saved"] = Map(
+            "Impostazioni salvate. Fai clic destro sul pannello per riaprirle.",
+            "Settings saved. Right-click the panel to reopen them.",
+            "Paramètres enregistrés. Faites un clic droit sur le panneau pour les rouvrir."),
+        ["settings.saveFailed"] = Map(
+            "Impossibile salvare le impostazioni. Le preferenze attive non sono cambiate. Verifica i permessi di scrittura e lo spazio disponibile, poi riprova.",
+            "Unable to save settings. Your active preferences are unchanged. Check write permissions and available disk space, then try again.",
+            "Impossible d'enregistrer les paramètres. Vos préférences actives sont inchangées. Vérifiez les autorisations d'écriture et l'espace disponible, puis réessayez."),
+        ["settings.customize"] = Map("Personalizza EdgePilot", "Customize EdgePilot", "Personnaliser EdgePilot"),
+        ["settings.screenEdge"] = Map("Bordo dello schermo", "Screen edge", "Bord de l'écran"),
+        ["settings.displayMode"] = Map("Visualizzazione", "Display mode", "Mode d'affichage"),
+        ["settings.visibleMetrics"] = Map("Metriche visibili", "Visible metrics", "Métriques visibles"),
+        ["settings.dataRefresh"] = Map("Aggiornamento dei dati", "Data refresh", "Actualisation des données"),
+        ["settings.sensitivityLabel"] = Map("Sensibilità di apertura", "Opening sensitivity", "Sensibilité d'ouverture"),
+        ["settings.sensitivityHint"] = Map(
+            "Ampia: il pannello si apre anche passando vicino alla linguetta. Precisa: occorre avvicinarsi di più al bordo.",
+            "Wide: the panel opens even when passing near the tab. Precise: you need to get closer to the edge.",
+            "Large : le panneau s'ouvre même en passant près de l'onglet. Précise : il faut s'approcher davantage du bord."),
+        ["settings.driveLabel"] = Map("Disco da visualizzare", "Disk to display", "Disque à afficher"),
+        ["settings.driveHint"] = Map(
+            "Sono elencati i volumi montati e accessibili. Se manca un disco, montalo: l'elenco si aggiorna automaticamente.",
+            "Mounted, accessible volumes are listed. If a disk is missing, mount it: the list updates automatically.",
+            "Les volumes montés et accessibles sont listés. Si un disque manque, montez-le : la liste se met à jour automatiquement."),
+        ["settings.languageLabel"] = Map("Lingua", "Language", "Langue"),
+        ["language.auto"] = Map("Automatica (sistema)", "Automatic (system)", "Automatique (système)"),
+
+        // Notch tooltip / rings
+        ["ring.disk"] = Map("DISCO", "DISK", "DISQUE"),
+        ["ring.network"] = Map("RETE", "NETWORK", "RÉSEAU"),
+        ["tooltip.systemMonitoring"] = Map("MONITORAGGIO SISTEMA", "SYSTEM MONITORING", "SURVEILLANCE SYSTÈME"),
+        ["tooltip.error"] = Map("ERRORE", "ERROR", "ERREUR"),
+        ["tooltip.updateFailed"] = Map("Impossibile aggiornare i dati del sistema.", "Unable to refresh system data.", "Impossible d'actualiser les données système."),
+        ["tooltip.retryNext"] = Map("Nuovo tentativo al prossimo aggiornamento.", "Will retry on the next update.", "Nouvelle tentative à la prochaine mise à jour."),
+        ["network.yes"] = Map("SÌ", "YES", "OUI"),
+        ["network.no"] = Map("NO", "NO", "NON"),
+        ["tooltip.processors"] = Map("{0} processori logici", "{0} logical processors", "{0} processeurs logiques"),
+        ["tooltip.memory"] = Map("MEMORIA", "MEMORY", "MÉMOIRE"),
+        ["bytes.used"] = Map("{0} utilizzati", "{0} used", "{0} utilisés"),
+        ["bytes.available"] = Map("{0} disponibili", "{0} available", "{0} disponibles"),
+        ["bytes.total"] = Map("{0} totali", "{0} total", "{0} au total"),
+        ["tooltip.storage"] = Map("ARCHIVIAZIONE", "STORAGE", "STOCKAGE"),
+        ["storage.noDisk"] = Map("Nessun disco disponibile", "No disk available", "Aucun disque disponible"),
+        ["storage.unavailable"] = Map("Il disco scelto non è disponibile", "Selected disk unavailable", "Disque sélectionné indisponible"),
+        ["storage.chooseInSettings"] = Map("Scegli il disco nelle impostazioni.", "Choose the disk in settings.", "Choisissez le disque dans les paramètres."),
+        ["bytes.free"] = Map("{0} liberi", "{0} free", "{0} libres"),
+        ["tooltip.network"] = Map("RETE", "NETWORK", "RÉSEAU"),
+        ["network.connected"] = Map("CONNESSA", "CONNECTED", "CONNECTÉ"),
+        ["network.disconnected"] = Map("DISCONNESSA", "DISCONNECTED", "DÉCONNECTÉ"),
+        ["network.noInterface"] = Map("Nessuna interfaccia di rete attiva", "No active network interface", "Aucune interface réseau active"),
+        ["network.linkSpeed"] = Map("Velocità collegamento: {0} Mbps", "Link speed: {0} Mbps", "Vitesse de liaison : {0} Mbps"),
+        ["network.uptime"] = Map("Tempo di attività: {0}", "Uptime: {0}", "Disponibilité : {0}"),
+    };
+
+    private static IReadOnlyDictionary<Language, string> Map(string italian, string english, string french) => new Dictionary<Language, string>
+    {
+        [Language.Italian] = italian,
+        [Language.English] = english,
+        [Language.French] = french,
+    };
+}

--- a/src/EdgePilot/EdgePilot.csproj
+++ b/src/EdgePilot/EdgePilot.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ApplicationIcon>Assets/edgepilot.ico</ApplicationIcon>
-    <Version>0.1.0-preview.1</Version>
+    <Version>0.2.0-preview.1</Version>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/src/EdgePilot/Platform/AutostartRegistration.cs
+++ b/src/EdgePilot/Platform/AutostartRegistration.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Win32;
+using EdgePilot.Core;
 using EdgePilot.UI;
 
 namespace EdgePilot.Platform;
@@ -14,12 +15,12 @@ public sealed record LaunchCommand(string Executable, IReadOnlyList<string> Argu
 {
     public static LaunchCommand Current()
     {
-        var executable = Environment.ProcessPath ?? throw new IOException("Percorso dell’app non disponibile.");
+        var executable = Environment.ProcessPath ?? throw new IOException(Localization.T("autostart.pathUnavailable"));
         var arguments = new List<string>();
         if (string.Equals(Path.GetFileNameWithoutExtension(executable), "dotnet", StringComparison.OrdinalIgnoreCase))
         {
             var assembly = Assembly.GetEntryAssembly()?.Location;
-            if (string.IsNullOrEmpty(assembly)) throw new IOException("Percorso dell’app non disponibile.");
+            if (string.IsNullOrEmpty(assembly)) throw new IOException(Localization.T("autostart.pathUnavailable"));
             arguments.Add(assembly);
         }
         arguments.Add("--autostart");
@@ -29,14 +30,14 @@ public sealed record LaunchCommand(string Executable, IReadOnlyList<string> Argu
     public string WindowsCommand()
     {
         var result = string.Join(" ", new[] { Executable }.Concat(Arguments).Select(QuoteWindows));
-        if (result.Length > 260) throw new IOException("Percorso troppo lungo per l’avvio automatico di Windows.");
+        if (result.Length > 260) throw new IOException(Localization.T("autostart.pathTooLong"));
         return result;
     }
 
     public string DesktopEntry()
     {
         var command = string.Join(" ", new[] { Executable }.Concat(Arguments).Select(QuoteDesktop));
-        return "[Desktop Entry]\nType=Application\nName=EdgePilot\nComment=Monitoraggio del sistema\nExec=" +
+        return $"[Desktop Entry]\nType=Application\nName=EdgePilot\nComment={Localization.T("desktop.comment")}\nExec=" +
             command.Replace("\\", "\\\\") +
             "\nTerminal=false\nX-GNOME-Autostart-enabled=true\n";
     }
@@ -44,7 +45,7 @@ public sealed record LaunchCommand(string Executable, IReadOnlyList<string> Argu
     private static void ValidateArgument(string value)
     {
         if (value.IndexOfAny(['\r', '\n', '\0']) >= 0)
-            throw new IOException("Il percorso dell’app contiene caratteri non supportati.");
+            throw new IOException(Localization.T("autostart.invalidChars"));
     }
 
     public static string QuoteWindows(string value)
@@ -103,7 +104,7 @@ public sealed class AutostartRegistration : IAutostartRegistration
         if (OperatingSystem.IsWindows())
         {
             using var key = Registry.CurrentUser.CreateSubKey(RunKey)
-                ?? throw new IOException("Impossibile aggiornare l’avvio automatico.");
+                ?? throw new IOException(Localization.T("autostart.updateFailed"));
             if (content is null) key.DeleteValue(ValueName, false);
             else key.SetValue(ValueName, content, RegistryValueKind.String);
             return;

--- a/src/EdgePilot/Platform/DesktopInstaller.cs
+++ b/src/EdgePilot/Platform/DesktopInstaller.cs
@@ -1,3 +1,5 @@
+using EdgePilot.Core;
+
 namespace EdgePilot.Platform;
 
 public static class DesktopInstaller
@@ -13,7 +15,7 @@ public static class DesktopInstaller
         if (!string.Equals(source, target, comparison))
         {
             if (target.StartsWith(source + Path.DirectorySeparatorChar, comparison))
-                throw new IOException("Estrai il pacchetto in una cartella separata prima di installarlo.");
+                throw new IOException(Localization.T("installer.extractFirst"));
             Directory.CreateDirectory(target);
             var options = new EnumerationOptions { RecurseSubdirectories = true, AttributesToSkip = FileAttributes.ReparsePoint };
             foreach (var file in Directory.EnumerateFiles(source, "*", options))
@@ -52,7 +54,7 @@ public static class DesktopInstaller
         if (!OperatingSystem.IsWindows()) return;
         var programs = Environment.GetFolderPath(Environment.SpecialFolder.Programs);
         Directory.CreateDirectory(programs);
-        var type = Type.GetTypeFromProgID("WScript.Shell") ?? throw new IOException("Menu Start non disponibile.");
+        var type = Type.GetTypeFromProgID("WScript.Shell") ?? throw new IOException(Localization.T("installer.startMenuUnavailable"));
         dynamic shell = Activator.CreateInstance(type)!;
         dynamic shortcut = shell.CreateShortcut(Path.Combine(programs, "EdgePilot.lnk"));
         shortcut.TargetPath = executable;

--- a/src/EdgePilot/Program.cs
+++ b/src/EdgePilot/Program.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using EdgePilot.Core;
 using EdgePilot.Platform;
 
 namespace EdgePilot;
@@ -8,6 +9,7 @@ internal static class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        Localization.SetLanguage(Localization.DetectSystemLanguage());
         if (args.Contains("--version"))
         {
             Console.WriteLine("EdgePilot " + typeof(Program).Assembly.GetName().Version);
@@ -15,10 +17,10 @@ internal static class Program
         }
         if (args.Contains("--install"))
         {
-            try { Console.WriteLine("EdgePilot installato in " + DesktopInstaller.Install()); }
+            try { Console.WriteLine(Localization.T("cli.installedTo", DesktopInstaller.Install())); }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Runtime.InteropServices.COMException)
             {
-                Console.Error.WriteLine("Installazione non riuscita. Chiudi EdgePilot e riprova. " + ex.Message);
+                Console.Error.WriteLine(Localization.T("cli.installFailed", ex.Message));
                 Environment.ExitCode = 1;
             }
             return;
@@ -28,7 +30,7 @@ internal static class Program
         {
             if (!args.Contains("--autostart") && !instance.NotifyPrimary())
             {
-                Console.Error.WriteLine("EdgePilot è già aperto ma non risponde. Chiudilo e riprova.");
+                Console.Error.WriteLine(Localization.T("cli.alreadyRunning"));
                 Environment.ExitCode = 1;
             }
             return;

--- a/src/EdgePilot/Properties/AssemblyInfo.cs
+++ b/src/EdgePilot/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("EdgePilot.UxChecks")]

--- a/src/EdgePilot/UI/AppIcon.cs
+++ b/src/EdgePilot/UI/AppIcon.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using EdgePilot.Core;
 
 namespace EdgePilot.UI;
 
@@ -7,7 +8,7 @@ public static class AppIcon
     public static WindowIcon Load()
     {
         using var stream = typeof(AppIcon).Assembly.GetManifestResourceStream("EdgePilot.Assets.edgepilot.ico")
-            ?? throw new IOException("Icona dell’app non disponibile.");
+            ?? throw new IOException(Localization.T("appicon.unavailable"));
         return new WindowIcon(stream);
     }
 }

--- a/src/EdgePilot/UI/DisplayFormat.cs
+++ b/src/EdgePilot/UI/DisplayFormat.cs
@@ -1,3 +1,5 @@
+using EdgePilot.Core;
+
 namespace EdgePilot.UI;
 
 internal static class DisplayFormat
@@ -23,7 +25,7 @@ internal static class DisplayFormat
 
     public static string Uptime(TimeSpan uptime)
     {
-        if (uptime.TotalDays >= 1) return $"{(int)uptime.TotalDays} g {uptime.Hours} h {uptime.Minutes} min";
+        if (uptime.TotalDays >= 1) return $"{(int)uptime.TotalDays} {Localization.T("time.dayUnit")} {uptime.Hours} h {uptime.Minutes} min";
         if (uptime.TotalHours >= 1) return $"{uptime.Hours} h {uptime.Minutes} min";
         return $"{uptime.Minutes} min {uptime.Seconds} s";
     }

--- a/src/EdgePilot/UI/DriveSelection.cs
+++ b/src/EdgePilot/UI/DriveSelection.cs
@@ -20,7 +20,7 @@ public static class DriveSelection
 
     public static IReadOnlyList<DriveChoice> Choices(IReadOnlyList<DriveSnapshot> drives, string? selected)
     {
-        var choices = new List<DriveChoice> { new(null, "Automatico (disco più capiente)") };
+        var choices = new List<DriveChoice> { new(null, Localization.T("drive.auto")) };
         foreach (var drive in drives)
         {
             var capacity = drive.TotalBytes >= 1_000_000_000_000L
@@ -29,7 +29,7 @@ public static class DriveSelection
             choices.Add(new(drive.Name, $"{drive.Label} · {drive.Name} · {capacity}"));
         }
         if (selected is not null && Resolve(drives, selected) is null)
-            choices.Add(new(selected, $"{selected} · non disponibile"));
+            choices.Add(new(selected, Localization.T("drive.unavailableSuffix", selected)));
         return choices;
     }
 }

--- a/src/EdgePilot/UI/EdgePilotLogo.cs
+++ b/src/EdgePilot/UI/EdgePilotLogo.cs
@@ -1,0 +1,84 @@
+using System.Xml.Linq;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Layout;
+
+namespace EdgePilot.UI;
+
+/// <summary>
+/// Renders the canonical EdgePilot SVG directly as Avalonia vector geometry.
+/// This keeps the in-app logo tied to Assets/edgepilot.svg without adding a
+/// second raster source or an SVG rendering dependency.
+/// </summary>
+public sealed class EdgePilotLogo : Viewbox
+{
+    public EdgePilotLogo()
+    {
+        Stretch = Stretch.Uniform;
+        HorizontalAlignment = HorizontalAlignment.Center;
+        VerticalAlignment = VerticalAlignment.Center;
+        Child = BuildLogo();
+    }
+
+    private static Control BuildLogo()
+    {
+        var canvas = new Canvas
+        {
+            Width = 1095,
+            Height = 1095
+        };
+
+        try
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Assets", "edgepilot.svg");
+            var document = XDocument.Load(path);
+            var svg = document.Root ?? throw new InvalidDataException("SVG root missing.");
+
+            var viewBox = ((string?)svg.Attribute("viewBox"))?.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (viewBox is { Length: 4 } &&
+                double.TryParse(viewBox[2], System.Globalization.CultureInfo.InvariantCulture, out var width) &&
+                double.TryParse(viewBox[3], System.Globalization.CultureInfo.InvariantCulture, out var height))
+            {
+                canvas.Width = width;
+                canvas.Height = height;
+            }
+
+            foreach (var node in svg.Elements().Where(x => x.Name.LocalName == "path"))
+            {
+                var data = (string?)node.Attribute("d");
+                var fill = (string?)node.Attribute("fill");
+                if (string.IsNullOrWhiteSpace(data) || string.IsNullOrWhiteSpace(fill)) continue;
+
+                canvas.Children.Add(new Avalonia.Controls.Shapes.Path
+                {
+                    Data = Geometry.Parse(data),
+                    Fill = new SolidColorBrush(Color.Parse(fill)),
+                    Stretch = Stretch.None
+                });
+            }
+
+            if (canvas.Children.Count > 0) return canvas;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException or InvalidDataException)
+        {
+            System.Diagnostics.Trace.WriteLine(ex);
+        }
+
+        return new Border
+        {
+            Width = 64,
+            Height = 64,
+            CornerRadius = new Avalonia.CornerRadius(16),
+            Background = new SolidColorBrush(Color.Parse("#252527")),
+            Child = new TextBlock
+            {
+                Text = "E",
+                FontSize = 30,
+                FontWeight = FontWeight.Bold,
+                Foreground = new SolidColorBrush(Color.Parse("#FF8A3D")),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            }
+        };
+    }
+}

--- a/src/EdgePilot/UI/EdgeWindow.cs
+++ b/src/EdgePilot/UI/EdgeWindow.cs
@@ -65,8 +65,10 @@ public sealed class EdgeWindow : Window
     private NotchDisplayMode _mode;
     private string? _selectedDrive;
     private bool _startAtLogin;
+    private Language? _language;
     public bool HasTray { get; set; }
     public event Action? ExitRequested;
+    public event Action? PreferencesChanged;
     public Action<NotchPreferences>? SavePreferences { get; set; }
     private SettingsWindow? _settingsWindow;
     private int? _hoveredMetric;
@@ -97,8 +99,8 @@ public sealed class EdgeWindow : Window
 
         _cpuRing = new MetricRing("C", "CPU");
         _ramRing = new MetricRing("M", "RAM");
-        _diskRing = new MetricRing("D", "DISCO");
-        _networkRing = new MetricRing("↕", "RETE");
+        _diskRing = new MetricRing("D", Localization.T("ring.disk"));
+        _networkRing = new MetricRing("↕", Localization.T("ring.network"));
 
         _metricStack = new StackPanel
         {
@@ -249,11 +251,11 @@ public sealed class EdgeWindow : Window
     {
         Dispatcher.UIThread.Post(() =>
         {
-            _tooltipTitle.Text = "MONITORAGGIO SISTEMA";
-            _tooltipValue.Text = "ERRORE";
+            _tooltipTitle.Text = Localization.T("tooltip.systemMonitoring");
+            _tooltipValue.Text = Localization.T("tooltip.error");
             System.Diagnostics.Trace.WriteLine(exception);
-            _tooltipLine1.Text = "Impossibile aggiornare i dati del sistema.";
-            _tooltipLine2.Text = "Nuovo tentativo al prossimo aggiornamento.";
+            _tooltipLine1.Text = Localization.T("tooltip.updateFailed");
+            _tooltipLine2.Text = Localization.T("tooltip.retryNext");
             _tooltipLine3.Text = "";
         });
     }
@@ -270,7 +272,7 @@ public sealed class EdgeWindow : Window
         _cpuRing.SetValue(cpu, $"{cpu:0}%");
         _ramRing.SetValue(ram, $"{ram:0}%");
         _diskRing.SetValue(drive?.UsedPercent, drive is null ? "—" : $"{drive.UsedPercent:0}%");
-        _networkRing.SetValue(null, snapshot.Network.Connected ? "SÌ" : "NO");
+        _networkRing.SetValue(null, snapshot.Network.Connected ? Localization.T("network.yes") : Localization.T("network.no"));
 
         if (_hoveredMetric is not null)
         {
@@ -446,47 +448,47 @@ public sealed class EdgeWindow : Window
             case 0:
                 _tooltipTitle.Text = "CPU";
                 _tooltipValue.Text = $"{cpu:0}%";
-                _tooltipLine1.Text = $"{Environment.ProcessorCount} processori logici";
+                _tooltipLine1.Text = Localization.T("tooltip.processors", Environment.ProcessorCount);
                 _tooltipLine2.Text = snapshot.HostName;
                 _tooltipLine3.Text = snapshot.OperatingSystem;
                 break;
 
             case 1:
-                _tooltipTitle.Text = "MEMORIA";
+                _tooltipTitle.Text = Localization.T("tooltip.memory");
                 _tooltipValue.Text = $"{ram:0}%";
-                _tooltipLine1.Text = $"{DisplayFormat.Bytes(snapshot.MemoryUsedBytes)} utilizzati";
-                _tooltipLine2.Text = $"{DisplayFormat.Bytes(snapshot.MemoryAvailableBytes)} disponibili";
-                _tooltipLine3.Text = $"{DisplayFormat.Bytes(snapshot.MemoryTotalBytes)} totali";
+                _tooltipLine1.Text = Localization.T("bytes.used", DisplayFormat.Bytes(snapshot.MemoryUsedBytes));
+                _tooltipLine2.Text = Localization.T("bytes.available", DisplayFormat.Bytes(snapshot.MemoryAvailableBytes));
+                _tooltipLine3.Text = Localization.T("bytes.total", DisplayFormat.Bytes(snapshot.MemoryTotalBytes));
                 break;
 
             case 2:
-                _tooltipTitle.Text = "ARCHIVIAZIONE";
+                _tooltipTitle.Text = Localization.T("tooltip.storage");
                 if (drive is null)
                 {
                     _tooltipValue.Text = "—";
-                    _tooltipLine1.Text = _selectedDrive is null ? "Nessun disco disponibile" : "Il disco scelto non è disponibile";
+                    _tooltipLine1.Text = _selectedDrive is null ? Localization.T("storage.noDisk") : Localization.T("storage.unavailable");
                     _tooltipLine2.Text = _selectedDrive ?? "";
-                    _tooltipLine3.Text = "Scegli il disco nelle impostazioni.";
+                    _tooltipLine3.Text = Localization.T("storage.chooseInSettings");
                 }
                 else
                 {
                     _tooltipValue.Text = $"{drive.UsedPercent:0}%";
                     _tooltipLine1.Text = drive.Label;
-                    _tooltipLine2.Text = $"{DisplayFormat.Bytes(drive.FreeBytes)} liberi";
-                    _tooltipLine3.Text = $"{DisplayFormat.Bytes(drive.TotalBytes)} totali";
+                    _tooltipLine2.Text = Localization.T("bytes.free", DisplayFormat.Bytes(drive.FreeBytes));
+                    _tooltipLine3.Text = Localization.T("bytes.total", DisplayFormat.Bytes(drive.TotalBytes));
                 }
                 break;
 
             default:
-                _tooltipTitle.Text = "RETE";
-                _tooltipValue.Text = snapshot.Network.Connected ? "CONNESSA" : "DISCONNESSA";
-                _tooltipLine1.Text = snapshot.Network.Connected ? snapshot.Network.InterfaceName : "Nessuna interfaccia di rete attiva";
+                _tooltipTitle.Text = Localization.T("tooltip.network");
+                _tooltipValue.Text = snapshot.Network.Connected ? Localization.T("network.connected") : Localization.T("network.disconnected");
+                _tooltipLine1.Text = snapshot.Network.Connected ? snapshot.Network.InterfaceName : Localization.T("network.noInterface");
                 _tooltipLine2.Text = snapshot.Network.Connected
                     ? $"↓ {DisplayFormat.Rate(snapshot.Network.ReceiveBytesPerSecond)}   ↑ {DisplayFormat.Rate(snapshot.Network.SendBytesPerSecond)}"
                     : "";
                 _tooltipLine3.Text = snapshot.Network.LinkSpeedBitsPerSecond > 0
-                    ? $"Velocità collegamento: {snapshot.Network.LinkSpeedBitsPerSecond / 1_000_000d:0} Mbps"
-                    : $"Tempo di attività: {DisplayFormat.Uptime(snapshot.Uptime)}";
+                    ? Localization.T("network.linkSpeed", (int)Math.Round(snapshot.Network.LinkSpeedBitsPerSecond / 1_000_000d))
+                    : Localization.T("network.uptime", DisplayFormat.Uptime(snapshot.Uptime));
                 break;
         }
     }
@@ -495,7 +497,8 @@ public sealed class EdgeWindow : Window
     {
         SelectedDrive = _selectedDrive, StartAtLogin = _startAtLogin,
         Metrics = _metrics, Sensitivity = _sensitivity,
-        RefreshIntervalMs = (int)_monitor.RefreshInterval.TotalMilliseconds
+        RefreshIntervalMs = (int)_monitor.RefreshInterval.TotalMilliseconds,
+        Language = _language
     };
 
     public void ApplyPreferences(NotchPreferences preferences)
@@ -510,6 +513,10 @@ public sealed class EdgeWindow : Window
         _startAtLogin = preferences.StartAtLogin;
         _metrics = preferences.Metrics;
         _sensitivity = preferences.Sensitivity;
+        _language = preferences.Language;
+        Localization.SetLanguage(preferences.Language ?? Localization.DetectSystemLanguage());
+        _diskRing.SetCaption(Localization.T("ring.disk"));
+        _networkRing.SetCaption(Localization.T("ring.network"));
         _monitor.RefreshInterval = TimeSpan.FromMilliseconds(preferences.RefreshIntervalMs);
         _visibleMetricIndices = Enumerable.Range(0, 4).Where(i => ((int)_metrics & (1 << i)) != 0).ToArray();
         _metricStack.Children.Clear();
@@ -534,6 +541,7 @@ public sealed class EdgeWindow : Window
         }
         if (_latestSnapshot is not null) RenderSnapshot(_latestSnapshot);
         Relocate();
+        PreferencesChanged?.Invoke();
     }
 
     public void RequestExit()
@@ -558,7 +566,7 @@ public sealed class EdgeWindow : Window
         CancelFold();
         _settingsWindow = new SettingsWindow(Preferences, ApplyPreferences, warning,
             drives: _latestSnapshot?.Drives, savePreferences: SavePreferences,
-            exit: RequestExit, hasTray: HasTray);
+            exit: RequestExit, hasTray: HasTray, reopen: () => Dispatcher.UIThread.Post(() => ShowSettings()));
         _settingsWindow.Closed += (_, _) =>
         {
             _settingsWindow = null;

--- a/src/EdgePilot/UI/MetricRing.cs
+++ b/src/EdgePilot/UI/MetricRing.cs
@@ -15,6 +15,7 @@ internal sealed class MetricRing : StackPanel
     private readonly Path _progress;
     private readonly TextBlock _glyph;
     private readonly TextBlock _value;
+    private readonly TextBlock _label;
 
     public MetricRing(string glyph, string caption)
     {
@@ -74,7 +75,7 @@ internal sealed class MetricRing : StackPanel
             TextAlignment = TextAlignment.Center
         };
 
-        var label = new TextBlock
+        _label = new TextBlock
         {
             Text = caption,
             FontSize = 8,
@@ -87,7 +88,7 @@ internal sealed class MetricRing : StackPanel
 
         Children.Add(ring);
         Children.Add(_value);
-        Children.Add(label);
+        Children.Add(_label);
 
         SetValue(null, "—");
     }
@@ -100,6 +101,8 @@ internal sealed class MetricRing : StackPanel
     }
 
     public void SetGlyph(string glyph) => _glyph.Text = glyph;
+
+    public void SetCaption(string caption) => _label.Text = caption;
 
     private static Geometry Arc(double percent)
     {

--- a/src/EdgePilot/UI/NotchPreferences.cs
+++ b/src/EdgePilot/UI/NotchPreferences.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using EdgePilot.Core;
 
 namespace EdgePilot.UI;
 
@@ -17,6 +18,8 @@ public sealed record NotchPreferences(EdgeSide Edge = EdgeSide.Right,
     public int RefreshIntervalMs { get; init; } = 1000;
     public HoverSensitivity Sensitivity { get; init; } = HoverSensitivity.Normal;
     public VisibleMetrics Metrics { get; init; } = VisibleMetrics.All;
+    // Null means "follow the system language".
+    public Language? Language { get; init; }
 }
 
 public static class PreferenceStore
@@ -34,20 +37,22 @@ public static class PreferenceStore
     public static void Validate(NotchPreferences value)
     {
         if (!Enum.IsDefined(value.Edge) || !Enum.IsDefined(value.Mode))
-            throw new InvalidDataException("Bordo o modalità di visualizzazione non supportati.");
+            throw new InvalidDataException(Localization.T("prefs.invalidEdgeMode"));
         if (value.RefreshIntervalMs is not (500 or 1000 or 2000 or 5000))
-            throw new InvalidDataException("Intervallo di aggiornamento non supportato.");
+            throw new InvalidDataException(Localization.T("prefs.invalidRefresh"));
         if (!Enum.IsDefined(value.Sensitivity))
-            throw new InvalidDataException("Sensibilità non supportata.");
+            throw new InvalidDataException(Localization.T("prefs.invalidSensitivity"));
         if (value.Metrics == 0 || (value.Metrics & ~VisibleMetrics.All) != 0)
-            throw new InvalidDataException("Seleziona almeno una metrica valida.");
+            throw new InvalidDataException(Localization.T("prefs.invalidMetrics"));
+        if (value.Language is { } language && !Enum.IsDefined(language))
+            throw new InvalidDataException(Localization.T("prefs.invalidLanguage"));
     }
 
     public static NotchPreferences Load(string path)
     {
         if (!File.Exists(path)) return new();
         var value = JsonSerializer.Deserialize<NotchPreferences>(File.ReadAllText(path), Options)
-            ?? throw new InvalidDataException("Il file delle impostazioni è vuoto.");
+            ?? throw new InvalidDataException(Localization.T("prefs.emptyFile"));
         Validate(value);
         return value;
     }

--- a/src/EdgePilot/UI/Settings/SettingsControls.cs
+++ b/src/EdgePilot/UI/Settings/SettingsControls.cs
@@ -1,0 +1,254 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using EdgePilot.Core;
+
+namespace EdgePilot.UI;
+
+public sealed partial class SettingsWindow
+{
+    private const string GitHubMarkPath =
+        "M6.766 11.328c-2.063-.25-3.516-1.734-3.516-3.656 0-.781.281-1.625.75-2.188-.203-.515-.172-1.609.063-2.062.625-.078 1.468.25 1.968.703.594-.187 1.219-.281 1.985-.281.765 0 1.39.094 1.953.265.484-.437 1.344-.765 1.969-.687.218.422.25 1.515.046 2.047.5.593.766 1.39.766 2.203 0 1.922-1.453 3.375-3.547 3.64.531.344.89 1.094.89 1.954v1.625c0 .468.391.734.86.547C13.781 14.359 16 11.53 16 8.03 16 3.61 12.406 0 7.984 0 3.563 0 0 3.61 0 8.031a7.88 7.88 0 0 0 5.172 7.422c.422.156.828-.125.828-.547v-1.25c-.219.094-.5.156-.75.156-1.031 0-1.64-.562-2.078-1.609-.172-.422-.36-.672-.719-.719-.187-.015-.25-.093-.25-.187 0-.188.313-.328.625-.328.453 0 .844.281 1.25.86.313.452.64.655 1.031.655s.641-.14 1-.5c.266-.265.47-.5.657-.656";
+
+    private Border Card(params Control[] children)
+    {
+        var stack = new StackPanel { Spacing = 12 };
+        foreach (var child in children) stack.Children.Add(child);
+        var card = new Border
+        {
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(14),
+            Padding = new Thickness(18),
+            Child = stack
+        };
+        _cards.Add(card);
+        return card;
+    }
+
+    private Border MetricTile(CheckBox checkbox, string icon, string description)
+    {
+        var heading = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto"),
+            ColumnSpacing = 9
+        };
+        heading.Children.Add(new TextBlock
+        {
+            Text = icon,
+            FontSize = 18,
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = AccentBrush
+        });
+        var title = new TextBlock
+        {
+            Text = checkbox.Content?.ToString(),
+            FontWeight = FontWeight.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        heading.Children.Add(title);
+        Grid.SetColumn(title, 1);
+        checkbox.Content = null;
+        heading.Children.Add(checkbox);
+        Grid.SetColumn(checkbox, 2);
+
+        var tile = new Border
+        {
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(11),
+            Padding = new Thickness(14),
+            Cursor = new Cursor(StandardCursorType.Hand),
+            Child = new StackPanel
+            {
+                Spacing = 7,
+                Children = { heading, Description(description) }
+            }
+        };
+        tile.PointerPressed += (_, e) =>
+        {
+            if (e.Source is CheckBox) return;
+            checkbox.IsChecked = checkbox.IsChecked != true;
+            OnMetricChanged();
+            e.Handled = true;
+        };
+        return tile;
+    }
+
+    private static Control SettingField(string label, Control control)
+    {
+        var stack = new StackPanel { Spacing = 6 };
+        stack.Children.Add(Label(label));
+        stack.Children.Add(control);
+        return stack;
+    }
+
+    private static TextBlock SectionTitle(string icon, string text) => new()
+    {
+        Text = $"{icon}  {text}",
+        FontSize = 16,
+        FontWeight = FontWeight.SemiBold
+    };
+
+    private static TextBlock Label(string text) => new()
+    {
+        Text = text,
+        FontWeight = FontWeight.SemiBold
+    };
+
+    private static TextBlock Description(string text) => new()
+    {
+        Text = text,
+        Foreground = MutedBrush,
+        FontSize = 12,
+        TextWrapping = TextWrapping.Wrap
+    };
+
+    private static Border Divider() => new()
+    {
+        Height = 1,
+        Background = new SolidColorBrush(Color.FromArgb(60, 128, 128, 128)),
+        Margin = new Thickness(0, 4)
+    };
+
+    private static WrapPanel SegmentRow(IEnumerable<Button> buttons)
+    {
+        var row = new WrapPanel { Orientation = Orientation.Horizontal };
+        foreach (var button in buttons)
+        {
+            button.Margin = new Thickness(0, 0, 8, 8);
+            row.Children.Add(button);
+        }
+        return row;
+    }
+
+    private static WrapPanel ChipRow(params string[] labels)
+    {
+        var row = new WrapPanel { Orientation = Orientation.Horizontal };
+        foreach (var label in labels)
+        {
+            row.Children.Add(new Border
+            {
+                Background = AccentSoftBrush,
+                CornerRadius = new CornerRadius(999),
+                Padding = new Thickness(9, 4),
+                Margin = new Thickness(0, 4, 7, 0),
+                Child = new TextBlock { Text = label, FontSize = 11, FontWeight = FontWeight.SemiBold }
+            });
+        }
+        return row;
+    }
+
+    private static StackPanel FeatureRow(string icon, string title, string description)
+    {
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = icon,
+                    FontSize = 18,
+                    Foreground = AccentBrush,
+                    Width = 24,
+                    VerticalAlignment = VerticalAlignment.Top
+                },
+                new StackPanel
+                {
+                    Spacing = 3,
+                    Children =
+                    {
+                        new TextBlock { Text = title, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap },
+                        Description(description)
+                    }
+                }
+            }
+        };
+    }
+
+    private static StackPanel ButtonContent(string icon, string text)
+    {
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 7,
+            Children =
+            {
+                new TextBlock { Text = icon, VerticalAlignment = VerticalAlignment.Center },
+                new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center }
+            }
+        };
+    }
+
+    private static Button SegmentButton(string? icon, string text, Action select)
+    {
+        var button = new Button
+        {
+            Content = string.IsNullOrWhiteSpace(icon) ? text : ButtonContent(icon, text),
+            Padding = new Thickness(13, 8),
+            MinWidth = 72
+        };
+        button.Click += (_, _) => select();
+        return button;
+    }
+
+    private Button NavButton(string icon, string text, SettingsPage page)
+    {
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 9,
+            Children =
+            {
+                new TextBlock { Text = icon, Width = 20, TextAlignment = TextAlignment.Center },
+                new TextBlock { Text = text, TextWrapping = TextWrapping.Wrap }
+            }
+        };
+        var button = new Button
+        {
+            Content = content,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+            Padding = new Thickness(11, 10),
+            BorderThickness = new Thickness(0)
+        };
+        button.Click += (_, _) => ShowPage(page);
+        _navButtons[page] = button;
+        return button;
+    }
+
+    private Button LinkButton(string text, string url)
+    {
+        var button = new Button
+        {
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                Children =
+                {
+                    new PathIcon { Data = Geometry.Parse(GitHubMarkPath), Width = 16, Height = 16 },
+                    new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center }
+                }
+            },
+            Padding = new Thickness(13, 8)
+        };
+        button.Click += (_, _) => OpenUrl(url);
+        return button;
+    }
+
+    private void OpenUrl(string url)
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            System.Diagnostics.Trace.WriteLine(ex);
+            _status.Text = Localization.T("settings.browserFailed");
+        }
+    }
+}

--- a/src/EdgePilot/UI/Settings/SettingsPages.cs
+++ b/src/EdgePilot/UI/Settings/SettingsPages.cs
@@ -1,0 +1,365 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using EdgePilot.Core;
+
+namespace EdgePilot.UI;
+
+public sealed partial class SettingsWindow
+{
+    private Border BuildHeader()
+    {
+        var title = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                new EdgePilotLogo { Width = 36, Height = 36 },
+                new StackPanel
+                {
+                    Spacing = 1,
+                    Children =
+                    {
+                        new TextBlock { Text = "EdgePilot", FontSize = 20, FontWeight = FontWeight.SemiBold },
+                        new TextBlock
+                        {
+                            Text = Localization.T("settings.headerSubtitle"),
+                            FontSize = 12,
+                            Foreground = MutedBrush
+                        }
+                    }
+                }
+            }
+        };
+
+        _versionBadge = new Border
+        {
+            Background = AccentSoftBrush,
+            BorderBrush = AccentBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(999),
+            Padding = new Thickness(10, 4),
+            VerticalAlignment = VerticalAlignment.Center,
+            Child = new TextBlock
+            {
+                Text = VersionLabel(),
+                FontSize = 10,
+                FontWeight = FontWeight.SemiBold
+            }
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            Margin = new Thickness(24, 0)
+        };
+        grid.Children.Add(title);
+        grid.Children.Add(_versionBadge);
+        Grid.SetColumn(_versionBadge, 1);
+
+        return new Border
+        {
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            Child = grid
+        };
+    }
+
+    private Border BuildSidebar()
+    {
+        var nav = new StackPanel
+        {
+            Spacing = 4,
+            Margin = new Thickness(12, 18)
+        };
+        nav.Children.Add(new TextBlock
+        {
+            Text = Localization.T("settings.sidebarHeading"),
+            FontSize = 10,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = MutedBrush,
+            Margin = new Thickness(10, 0, 0, 8)
+        });
+        nav.Children.Add(NavButton("◨", Localization.T("nav.edge"), SettingsPage.Edge));
+        nav.Children.Add(NavButton("▦", Localization.T("nav.monitor"), SettingsPage.Monitor));
+        nav.Children.Add(NavButton("⚙", Localization.T("nav.behavior"), SettingsPage.Behavior));
+        nav.Children.Add(NavButton("↻", Localization.T("nav.startup"), SettingsPage.Startup));
+        nav.Children.Add(NavButton("ⓘ", Localization.T("nav.about"), SettingsPage.About));
+
+        return new Border
+        {
+            BorderThickness = new Thickness(0, 0, 1, 0),
+            Child = nav
+        };
+    }
+
+    private Border BuildFooter()
+    {
+        var statusDot = new Border
+        {
+            Width = 7,
+            Height = 7,
+            Background = AccentBrush,
+            CornerRadius = new CornerRadius(4),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 9, 0)
+        };
+        var statusRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { statusDot, _status }
+        };
+
+        var actions = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { _resetButton, _applyButton }
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            Margin = new Thickness(24, 0)
+        };
+        grid.Children.Add(statusRow);
+        grid.Children.Add(actions);
+        Grid.SetColumn(actions, 1);
+
+        return new Border
+        {
+            BorderThickness = new Thickness(0, 1, 0, 0),
+            Child = grid
+        };
+    }
+
+    private Control BuildEdgePage()
+    {
+        _positionOptions = new StackPanel
+        {
+            Spacing = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                Label(Localization.T("edge.positionLabel")),
+                Description(Localization.T("edge.positionHint")),
+                SegmentRow(_edgeButtons)
+            }
+        };
+
+        _previewLayout = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,*"),
+            RowDefinitions = new RowDefinitions("Auto"),
+            ColumnSpacing = 24
+        };
+        _previewLayout.Children.Add(_previewFrame);
+        _previewLayout.Children.Add(_positionOptions);
+        Grid.SetColumn(_positionOptions, 1);
+
+        return Page(
+            Localization.T("edge.pageTitle"),
+            Localization.T("edge.pageSubtitle"),
+            Card(
+                SectionTitle("◨", Localization.T("edge.positionTitle")),
+                Description(Localization.T("edge.positionDescription")),
+                _previewLayout),
+            Card(
+                SectionTitle("◌", Localization.T("edge.behaviorTitle")),
+                Description(Localization.T("edge.behaviorDescription")),
+                SegmentRow(_modeButtons)));
+    }
+
+    private Control BuildMonitorPage()
+    {
+        _metricGrid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,*"),
+            RowDefinitions = new RowDefinitions("Auto,Auto"),
+            ColumnSpacing = 12,
+            RowSpacing = 12
+        };
+
+        var descriptions = new[]
+        {
+            Localization.T("metric.cpu.description"),
+            Localization.T("metric.memory.description"),
+            Localization.T("metric.disk.description"),
+            Localization.T("metric.network.description")
+        };
+        var icons = new[] { "◉", "▤", "▱", "↕" };
+        _metricTiles = new Border[_metrics.Length];
+        for (var i = 0; i < _metrics.Length; i++)
+        {
+            var tile = MetricTile(_metrics[i], icons[i], descriptions[i]);
+            _metricTiles[i] = tile;
+            _metricGrid.Children.Add(tile);
+            Grid.SetColumn(tile, i % 2);
+            Grid.SetRow(tile, i / 2);
+        }
+
+        _diskCard = Card(
+            SectionTitle("▱", Localization.T("monitor.diskTitle")),
+            Description(Localization.T("monitor.diskDescription")),
+            _drive);
+
+        return Page(
+            Localization.T("monitor.pageTitle"),
+            Localization.T("monitor.pageSubtitle"),
+            Card(
+                SectionTitle("▦", Localization.T("monitor.metricsTitle")),
+                Description(Localization.T("monitor.metricsDescription")),
+                _metricGrid),
+            _diskCard);
+    }
+
+    private Control BuildBehaviorPage()
+    {
+        return Page(
+            Localization.T("behavior.pageTitle"),
+            Localization.T("behavior.pageSubtitle"),
+            Card(
+                SectionTitle("↻", Localization.T("behavior.refreshTitle")),
+                Description(Localization.T("behavior.refreshDescription")),
+                SettingField(Localization.T("behavior.refreshLabel"), _refresh)),
+            Card(
+                SectionTitle("◎", Localization.T("behavior.sensitivityTitle")),
+                Description(Localization.T("behavior.sensitivityDescription")),
+                SegmentRow(_sensitivityButtons)),
+            Card(
+                SectionTitle("文", Localization.T("behavior.languageTitle")),
+                Description(Localization.T("behavior.languageDescription")),
+                _language));
+    }
+
+    private Control BuildStartupPage(Action? exit)
+    {
+        var exitButton = new Button
+        {
+            Content = ButtonContent("⏻", Localization.T("startup.exitButton")),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Padding = new Thickness(14, 8)
+        };
+        exitButton.Click += (_, _) =>
+        {
+            if (exit is not null) exit();
+            else Close();
+        };
+
+        return Page(
+            Localization.T("startup.pageTitle"),
+            Localization.T("startup.pageSubtitle"),
+            Card(
+                SectionTitle("↻", Localization.T("startup.autostartTitle")),
+                Description(Localization.T("startup.autostartDescription")),
+                _autostart),
+            Card(
+                SectionTitle("⏻", Localization.T("startup.sessionTitle")),
+                Description(Localization.T("startup.sessionDescription")),
+                exitButton));
+    }
+
+    private Control BuildAboutPage()
+    {
+        var hero = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,*"),
+            ColumnSpacing = 20
+        };
+        var logo = new EdgePilotLogo
+        {
+            Width = 76,
+            Height = 76,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        hero.Children.Add(logo);
+
+        var heroText = new StackPanel
+        {
+            Spacing = 6,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = "EdgePilot",
+                    FontSize = 28,
+                    FontWeight = FontWeight.SemiBold
+                },
+                new TextBlock
+                {
+                    Text = "Your desktop has edges. EdgePilot makes them useful.",
+                    FontSize = 16,
+                    TextWrapping = TextWrapping.Wrap
+                },
+                Description(Localization.T("about.productDescription")),
+                ChipRow("Open source", "MIT", "Windows + Linux", "Local-first")
+            }
+        };
+        hero.Children.Add(heroText);
+        Grid.SetColumn(heroText, 1);
+
+        var repoButton = LinkButton(Localization.T("about.repoButton"), "https://github.com/pricootz/edgepilot");
+        var profileButton = LinkButton(Localization.T("about.profileButton"), "https://github.com/pricootz");
+
+        return Page(
+            Localization.T("about.pageTitle"),
+            Localization.T("about.pageSubtitle"),
+            Card(hero),
+            Card(
+                SectionTitle("✦", Localization.T("about.authorTitle")),
+                new TextBlock
+                {
+                    Text = Localization.T("about.authorLine"),
+                    FontSize = 18,
+                    FontWeight = FontWeight.SemiBold,
+                    TextWrapping = TextWrapping.Wrap
+                },
+                Description(Localization.T("about.authorDescription")),
+                SegmentRow(new[] { repoButton, profileButton })),
+            Card(
+                SectionTitle("⌁", Localization.T("about.philosophyTitle")),
+                FeatureRow("◉", Localization.T("about.localTitle"), Localization.T("about.localDescription")),
+                Divider(),
+                FeatureRow("◨", Localization.T("about.edgeNativeTitle"), Localization.T("about.edgeNativeDescription")),
+                Divider(),
+                FeatureRow("◇", Localization.T("about.evolvingTitle"), Localization.T("about.evolvingDescription"))),
+            Card(
+                SectionTitle("ⓘ", Localization.T("about.versionTitle")),
+                new TextBlock { Text = FullVersionLabel(), FontWeight = FontWeight.SemiBold },
+                Description(Localization.T("about.versionDescription"))));
+    }
+
+    private ScrollViewer Page(string title, string subtitle, params Control[] sections)
+    {
+        var stack = new StackPanel
+        {
+            Margin = new Thickness(28, 24, 28, 28),
+            Spacing = 16
+        };
+        _pageStacks.Add(stack);
+        stack.Children.Add(new TextBlock
+        {
+            Text = title,
+            FontSize = 28,
+            FontWeight = FontWeight.SemiBold
+        });
+        stack.Children.Add(new TextBlock
+        {
+            Text = subtitle,
+            Foreground = MutedBrush,
+            FontSize = 14,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, -8, 0, 8)
+        });
+        foreach (var section in sections) stack.Children.Add(section);
+        return new ScrollViewer
+        {
+            Content = stack,
+            HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled
+        };
+    }
+}

--- a/src/EdgePilot/UI/SettingsWindow.cs
+++ b/src/EdgePilot/UI/SettingsWindow.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
@@ -14,6 +16,11 @@ public sealed class SettingsWindow : Window
     private static readonly IBrush PreviewBackgroundBrush = new SolidColorBrush(Color.Parse("#101114"));
     private static readonly IBrush PreviewBorderBrush = new SolidColorBrush(Color.Parse("#404247"));
     private static readonly IBrush MutedBrush = new SolidColorBrush(Color.Parse("#8D9096"));
+    private static readonly VisibleMetrics[] MetricOptions =
+        { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
+
+    private const string GitHubMarkPath =
+        "M6.766 11.328c-2.063-.25-3.516-1.734-3.516-3.656 0-.781.281-1.625.75-2.188-.203-.515-.172-1.609.063-2.062.625-.078 1.468.25 1.968.703.594-.187 1.219-.281 1.985-.281.765 0 1.39.094 1.953.265.484-.437 1.344-.765 1.969-.687.218.422.25 1.515.046 2.047.5.593.766 1.39.766 2.203 0 1.922-1.453 3.375-3.547 3.64.531.344.89 1.094.89 1.954v1.625c0 .468.391.734.86.547C13.781 14.359 16 11.53 16 8.03 16 3.61 12.406 0 7.984 0 3.563 0 0 3.61 0 8.031a7.88 7.88 0 0 0 5.172 7.422c.422.156.828-.125.828-.547v-1.25c-.219.094-.5.156-.75.156-1.031 0-1.64-.562-2.078-1.609-.172-.422-.36-.672-.719-.719-.187-.015-.25-.093-.25-.187 0-.188.313-.328.625-.328.453 0 .844.281 1.25.86.313.452.64.655 1.031.655s.641-.14 1-.5c.266-.265.47-.5.657-.656";
 
     private readonly ComboBox _drive;
     private readonly ComboBox _refresh;
@@ -34,9 +41,17 @@ public sealed class SettingsWindow : Window
     private readonly Dictionary<SettingsPage, Button> _navButtons = new();
     private readonly Dictionary<SettingsPage, Control> _pages = new();
     private readonly List<Border> _cards = new();
-    private readonly List<Border> _tiles = new();
+    private readonly List<StackPanel> _pageStacks = new();
     private readonly string? _initialDrive;
     private readonly int[] _intervals = { 500, 1000, 2000, 5000 };
+
+    private Border _diskCard = null!;
+    private Border[] _metricTiles = Array.Empty<Border>();
+    private Grid _body = null!;
+    private Grid _previewLayout = null!;
+    private StackPanel _positionOptions = null!;
+    private Grid _metricGrid = null!;
+    private Border _versionBadge = null!;
 
     private NotchPreferences _savedPreferences;
     private EdgeSide _selectedEdge;
@@ -44,6 +59,7 @@ public sealed class SettingsWindow : Window
     private HoverSensitivity _selectedSensitivity;
     private SettingsPage _selectedPage;
     private bool _ready;
+    private bool _darkTheme;
 
     public SettingsWindow(NotchPreferences current, Action<NotchPreferences> apply, string? warning = null, string? storagePath = null,
         IReadOnlyList<DriveSnapshot>? drives = null, Action<NotchPreferences>? savePreferences = null,
@@ -57,10 +73,10 @@ public sealed class SettingsWindow : Window
 
         Title = "EdgePilot · Impostazioni";
         Icon = AppIcon.Load();
-        Width = 900;
-        Height = 640;
-        MinWidth = 760;
-        MinHeight = 560;
+        Width = 920;
+        Height = 680;
+        MinWidth = 680;
+        MinHeight = 520;
         CanResize = true;
         WindowStartupLocation = WindowStartupLocation.CenterScreen;
         RequestedThemeVariant = OperatingSystem.IsLinux() ? ThemeVariant.Default : ThemeVariant.Dark;
@@ -69,7 +85,7 @@ public sealed class SettingsWindow : Window
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
             MaxDropDownHeight = 280,
-            MinWidth = 260
+            MaxWidth = 460
         };
         UpdateDrives(drives ?? Array.Empty<DriveSnapshot>());
 
@@ -77,22 +93,23 @@ public sealed class SettingsWindow : Window
         {
             ItemsSource = new[] { "Ogni 0,5 secondi", "Ogni secondo", "Ogni 2 secondi", "Ogni 5 secondi" },
             SelectedIndex = Array.IndexOf(_intervals, current.RefreshIntervalMs),
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            MinWidth = 220
+            HorizontalAlignment = HorizontalAlignment.Left,
+            MaxWidth = 320,
+            MinWidth = 210
         };
 
-        var metricOptions = new[] { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
         var metricNames = new[] { "CPU", "Memoria", "Disco", "Rete" };
-        _metrics = metricOptions.Select((flag, index) => new CheckBox
+        _metrics = MetricOptions.Select((flag, index) => new CheckBox
         {
             Content = metricNames[index],
             IsChecked = current.Metrics.HasFlag(flag),
-            FontWeight = FontWeight.SemiBold
+            FontWeight = FontWeight.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center
         }).ToArray();
 
         _autostart = new CheckBox
         {
-            Content = "Avvia EdgePilot all’accesso",
+            Content = "Avvia EdgePilot quando accedo al sistema",
             IsChecked = current.StartAtLogin,
             FontWeight = FontWeight.SemiBold
         };
@@ -121,22 +138,23 @@ public sealed class SettingsWindow : Window
             BorderBrush = PreviewBorderBrush,
             BorderThickness = new Thickness(1),
             CornerRadius = new CornerRadius(14),
-            Child = previewGrid
+            Child = previewGrid,
+            HorizontalAlignment = HorizontalAlignment.Center
         };
 
         _edgeButtons =
         [
-            SegmentButton("Destra", () => SelectEdge(EdgeSide.Right)),
-            SegmentButton("Sinistra", () => SelectEdge(EdgeSide.Left)),
-            SegmentButton("Alto", () => SelectEdge(EdgeSide.Top)),
-            SegmentButton("Basso", () => SelectEdge(EdgeSide.Bottom))
+            SegmentButton("▸  Destra", () => SelectEdge(EdgeSide.Right)),
+            SegmentButton("◂  Sinistra", () => SelectEdge(EdgeSide.Left)),
+            SegmentButton("▴  Alto", () => SelectEdge(EdgeSide.Top)),
+            SegmentButton("▾  Basso", () => SelectEdge(EdgeSide.Bottom))
         ];
 
         _modeButtons =
         [
-            SegmentButton("Hover", () => SelectMode(NotchDisplayMode.Hover)),
-            SegmentButton("Sempre aperto", () => SelectMode(NotchDisplayMode.Always)),
-            SegmentButton("Nascosto", () => SelectMode(NotchDisplayMode.Hidden))
+            SegmentButton("◌  Al passaggio", () => SelectMode(NotchDisplayMode.Hover)),
+            SegmentButton("●  Sempre visibile", () => SelectMode(NotchDisplayMode.Always)),
+            SegmentButton("○  Nascosto", () => SelectMode(NotchDisplayMode.Hidden))
         ];
 
         _sensitivityButtons =
@@ -148,29 +166,31 @@ public sealed class SettingsWindow : Window
 
         _status = new TextBlock
         {
-            Text = warning ?? "Nessuna modifica da salvare.",
+            Text = warning ?? "Tutto salvato.",
             TextWrapping = TextWrapping.Wrap,
-            VerticalAlignment = VerticalAlignment.Center
+            VerticalAlignment = VerticalAlignment.Center,
+            MaxLines = 2
         };
 
         _applyButton = new Button
         {
-            Content = "Salva modifiche",
+            Content = ButtonContent("✓", "Salva modifiche"),
             Background = AccentBrush,
-            Padding = new Thickness(18, 9),
-            MinWidth = 130,
+            Padding = new Thickness(17, 9),
+            MinWidth = 146,
             IsEnabled = false
         };
         _resetButton = new Button
         {
-            Content = "Annulla modifiche",
+            Content = ButtonContent("↶", "Annulla"),
             Padding = new Thickness(14, 9),
+            MinWidth = 100,
             IsEnabled = false
         };
 
         _drive.SelectionChanged += (_, _) => MarkDirty();
         _refresh.SelectionChanged += (_, _) => MarkDirty();
-        foreach (var metric in _metrics) metric.Click += (_, _) => MarkDirty();
+        foreach (var metric in _metrics) metric.Click += (_, _) => OnMetricChanged();
         _autostart.Click += (_, _) => MarkDirty();
 
         _resetButton.Click += (_, _) => ResetToSaved();
@@ -199,16 +219,16 @@ public sealed class SettingsWindow : Window
         shell.Children.Add(_header);
         Grid.SetRow(_header, 0);
 
-        var body = new Grid
+        _body = new Grid
         {
-            ColumnDefinitions = new ColumnDefinitions("190,*")
+            ColumnDefinitions = new ColumnDefinitions("184,*")
         };
-        body.Children.Add(_sidebar);
+        _body.Children.Add(_sidebar);
         Grid.SetColumn(_sidebar, 0);
-        body.Children.Add(_pageHost);
+        _body.Children.Add(_pageHost);
         Grid.SetColumn(_pageHost, 1);
-        shell.Children.Add(body);
-        Grid.SetRow(body, 1);
+        shell.Children.Add(_body);
+        Grid.SetRow(_body, 1);
 
         shell.Children.Add(_footer);
         Grid.SetRow(_footer, 2);
@@ -218,9 +238,13 @@ public sealed class SettingsWindow : Window
         SelectEdge(current.Edge, markDirty: false);
         SelectMode(current.Mode, markDirty: false);
         SelectSensitivity(current.Sensitivity, markDirty: false);
+        UpdateConditionalSettings();
         ShowPage(SettingsPage.Edge);
         ApplyTheme();
+        ApplyResponsiveLayout(Width);
+
         ActualThemeVariantChanged += (_, _) => ApplyTheme();
+        SizeChanged += (_, e) => ApplyResponsiveLayout(e.NewSize.Width);
     }
 
     public void UpdateDrives(IReadOnlyList<DriveSnapshot> drives)
@@ -242,13 +266,7 @@ public sealed class SettingsWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             Children =
             {
-                new Border
-                {
-                    Width = 7,
-                    Height = 32,
-                    Background = AccentBrush,
-                    CornerRadius = new CornerRadius(4)
-                },
+                new EdgePilotLogo { Width = 36, Height = 36 },
                 new StackPanel
                 {
                     Spacing = 1,
@@ -261,7 +279,7 @@ public sealed class SettingsWindow : Window
             }
         };
 
-        var badge = new Border
+        _versionBadge = new Border
         {
             Background = AccentSoftBrush,
             BorderBrush = AccentBrush,
@@ -271,7 +289,7 @@ public sealed class SettingsWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             Child = new TextBlock
             {
-                Text = "PREVIEW 0.1",
+                Text = VersionLabel(),
                 FontSize = 10,
                 FontWeight = FontWeight.SemiBold
             }
@@ -283,8 +301,8 @@ public sealed class SettingsWindow : Window
             Margin = new Thickness(24, 0)
         };
         grid.Children.Add(title);
-        grid.Children.Add(badge);
-        Grid.SetColumn(badge, 1);
+        grid.Children.Add(_versionBadge);
+        Grid.SetColumn(_versionBadge, 1);
 
         return new Border
         {
@@ -298,21 +316,21 @@ public sealed class SettingsWindow : Window
         var nav = new StackPanel
         {
             Spacing = 4,
-            Margin = new Thickness(14, 18)
+            Margin = new Thickness(12, 18)
         };
         nav.Children.Add(new TextBlock
         {
-            Text = "SETTINGS",
+            Text = "IMPOSTAZIONI",
             FontSize = 10,
             FontWeight = FontWeight.SemiBold,
             Foreground = MutedBrush,
             Margin = new Thickness(10, 0, 0, 8)
         });
-        nav.Children.Add(NavButton("Edge", SettingsPage.Edge));
-        nav.Children.Add(NavButton("Monitor", SettingsPage.Monitor));
-        nav.Children.Add(NavButton("Behavior", SettingsPage.Behavior));
-        nav.Children.Add(NavButton("Startup", SettingsPage.Startup));
-        nav.Children.Add(NavButton("About", SettingsPage.About));
+        nav.Children.Add(NavButton("◨", "Bordo", SettingsPage.Edge));
+        nav.Children.Add(NavButton("▦", "Monitor", SettingsPage.Monitor));
+        nav.Children.Add(NavButton("⚙", "Comportamento", SettingsPage.Behavior));
+        nav.Children.Add(NavButton("↻", "Avvio", SettingsPage.Startup));
+        nav.Children.Add(NavButton("ⓘ", "Informazioni", SettingsPage.About));
 
         return new Border
         {
@@ -365,43 +383,44 @@ public sealed class SettingsWindow : Window
 
     private Control BuildEdgePage()
     {
-        var positionOptions = new StackPanel
+        _positionOptions = new StackPanel
         {
-            Spacing = 12,
+            Spacing = 10,
             VerticalAlignment = VerticalAlignment.Center,
             Children =
             {
                 Label("Posizione"),
-                Description("Scegli da quale bordo EdgePilot deve emergere."),
+                Description("Scegli il bordo da cui EdgePilot deve emergere."),
                 SegmentRow(_edgeButtons)
             }
         };
 
-        var previewLayout = new Grid
+        _previewLayout = new Grid
         {
             ColumnDefinitions = new ColumnDefinitions("Auto,*"),
+            RowDefinitions = new RowDefinitions("Auto"),
             ColumnSpacing = 24
         };
-        previewLayout.Children.Add(_previewFrame);
-        previewLayout.Children.Add(positionOptions);
-        Grid.SetColumn(positionOptions, 1);
+        _previewLayout.Children.Add(_previewFrame);
+        _previewLayout.Children.Add(_positionOptions);
+        Grid.SetColumn(_positionOptions, 1);
 
         return Page(
-            "Edge",
-            "Decidi dove vive EdgePilot e come deve comparire sul desktop.",
+            "Bordo e presenza",
+            "Definisci dove vive EdgePilot e quanto deve essere presente sul desktop.",
             Card(
-                SectionTitle("Bordo dello schermo"),
-                Description("La preview mostra la posizione reale della linguetta rispetto allo schermo."),
-                previewLayout),
+                SectionTitle("◨", "Posizione sullo schermo"),
+                Description("La preview cambia insieme alla scelta e mostra dove comparirà la linguetta."),
+                _previewLayout),
             Card(
-                SectionTitle("Visualizzazione"),
-                Description("Hover resta discreto, Sempre aperto mantiene il pannello visibile, Nascosto lo rimuove dal bordo."),
+                SectionTitle("◌", "Comportamento del pannello"),
+                Description("Al passaggio mantiene EdgePilot discreto. Sempre visibile lo lascia aperto. Nascosto lo rimuove dal bordo finché non lo riapri dalla tray o dalle impostazioni."),
                 SegmentRow(_modeButtons)));
     }
 
     private Control BuildMonitorPage()
     {
-        var grid = new Grid
+        _metricGrid = new Grid
         {
             ColumnDefinitions = new ColumnDefinitions("*,*"),
             RowDefinitions = new RowDefinitions("Auto,Auto"),
@@ -411,44 +430,49 @@ public sealed class SettingsWindow : Window
 
         var descriptions = new[]
         {
-            "Utilizzo del processore",
-            "Memoria in uso",
-            "Spazio del volume selezionato",
-            "Download e upload"
+            "Carico del processore in tempo reale",
+            "Memoria RAM attualmente utilizzata",
+            "Spazio occupato sul volume scelto",
+            "Traffico di download e upload"
         };
+        var icons = new[] { "◉", "▤", "▱", "↕" };
+        _metricTiles = new Border[_metrics.Length];
         for (var i = 0; i < _metrics.Length; i++)
         {
-            var tile = MetricTile(_metrics[i], descriptions[i]);
-            grid.Children.Add(tile);
+            var tile = MetricTile(_metrics[i], icons[i], descriptions[i]);
+            _metricTiles[i] = tile;
+            _metricGrid.Children.Add(tile);
             Grid.SetColumn(tile, i % 2);
             Grid.SetRow(tile, i / 2);
         }
 
+        _diskCard = Card(
+            SectionTitle("▱", "Volume per la metrica Disco"),
+            Description("Questa scelta compare solo quando la metrica Disco è attiva. EdgePilot conserva comunque la selezione se la disattivi temporaneamente."),
+            _drive);
+
         return Page(
-            "Monitor",
-            "Scegli quali informazioni del modulo System devono apparire nella notch.",
+            "Monitor di sistema",
+            "Decidi quali dati del modulo System devono comparire nella notch.",
             Card(
-                SectionTitle("Metriche visibili"),
-                Description("Mostra solo ciò che ti serve. EdgePilot adatta automaticamente l’altezza del pannello."),
-                grid),
-            Card(
-                SectionTitle("Disco"),
-                Description("Seleziona il volume usato dalla metrica Disco. I volumi montati vengono aggiornati automaticamente."),
-                _drive));
+                SectionTitle("▦", "Metriche visibili"),
+                Description("Fai clic sull’intera scheda per attivare o disattivare una metrica. La notch si ridimensiona automaticamente."),
+                _metricGrid),
+            _diskCard);
     }
 
     private Control BuildBehaviorPage()
     {
         return Page(
-            "Behavior",
-            "Regola frequenza dei dati e sensibilità dell’interazione con il bordo.",
+            "Comportamento",
+            "Regola quanto spesso EdgePilot aggiorna i dati e quanto facilmente reagisce al bordo.",
             Card(
-                SectionTitle("Aggiornamento dei dati"),
-                Description("Una frequenza più alta rende i valori più reattivi; una più bassa riduce il lavoro in background."),
-                _refresh),
+                SectionTitle("↻", "Frequenza di aggiornamento"),
+                Description("Un intervallo breve rende i valori più reattivi. Un intervallo più lungo riduce leggermente il lavoro in background."),
+                SettingField("Aggiorna i dati", _refresh)),
             Card(
-                SectionTitle("Sensibilità di apertura"),
-                Description("Precisa richiede di arrivare vicino alla linguetta. Ampia rende più facile intercettare EdgePilot passando vicino al bordo."),
+                SectionTitle("◎", "Sensibilità al bordo"),
+                Description("Precisa richiede di arrivare vicino alla linguetta. Ampia crea una zona di aggancio più generosa. Normale è il compromesso consigliato."),
                 SegmentRow(_sensitivityButtons)));
     }
 
@@ -456,7 +480,7 @@ public sealed class SettingsWindow : Window
     {
         var exitButton = new Button
         {
-            Content = "Esci da EdgePilot",
+            Content = ButtonContent("⏻", "Esci da EdgePilot"),
             HorizontalAlignment = HorizontalAlignment.Left,
             Padding = new Thickness(14, 8)
         };
@@ -467,28 +491,42 @@ public sealed class SettingsWindow : Window
         };
 
         return Page(
-            "Startup",
-            "Controlla come EdgePilot si avvia e rimane disponibile nella sessione desktop.",
+            "Avvio e sessione",
+            "Scegli come EdgePilot entra nella sessione e quando deve terminare completamente.",
             Card(
-                SectionTitle("Avvio automatico"),
-                Description("Avvia EdgePilot per l’utente corrente quando accedi al sistema."),
+                SectionTitle("↻", "Avvio automatico"),
+                Description("Abilita l’avvio per l’utente corrente. EdgePilot resterà disponibile senza doverlo lanciare manualmente a ogni accesso."),
                 _autostart),
             Card(
-                SectionTitle("Sessione"),
-                Description("Chiude completamente EdgePilot e il processo in esecuzione."),
+                SectionTitle("⏻", "Sessione corrente"),
+                Description("Chiude completamente EdgePilot, inclusi pannello e processo in background."),
                 exitButton));
     }
 
     private Control BuildAboutPage()
     {
-        return Page(
-            "About",
-            "Informazioni sul progetto e sui principi della preview corrente.",
-            Card(
+        var hero = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,*"),
+            ColumnSpacing = 20
+        };
+        var logo = new EdgePilotLogo
+        {
+            Width = 76,
+            Height = 76,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        hero.Children.Add(logo);
+
+        var heroText = new StackPanel
+        {
+            Spacing = 6,
+            Children =
+            {
                 new TextBlock
                 {
                     Text = "EdgePilot",
-                    FontSize = 26,
+                    FontSize = 28,
                     FontWeight = FontWeight.SemiBold
                 },
                 new TextBlock
@@ -497,23 +535,52 @@ public sealed class SettingsWindow : Window
                     FontSize = 16,
                     TextWrapping = TextWrapping.Wrap
                 },
-                Description("Early preview · Windows + Linux · Avalonia + .NET"),
-                Divider(),
+                Description("Una superficie desktop edge-native per Windows e Linux, progettata per mostrare informazioni e azioni solo quando servono."),
+                ChipRow("Open source", "MIT", "Windows + Linux", "Local-first")
+            }
+        };
+        hero.Children.Add(heroText);
+        Grid.SetColumn(heroText, 1);
+
+        var repoButton = LinkButton("Repository GitHub", "https://github.com/pricootz/edgepilot");
+        var profileButton = LinkButton("Profilo @pricootz", "https://github.com/pricootz");
+
+        return Page(
+            "Informazioni",
+            "Il progetto, chi lo sviluppa e i principi su cui viene costruito.",
+            Card(hero),
+            Card(
+                SectionTitle("✦", "Autore"),
                 new TextBlock
                 {
-                    Text = "Local first",
-                    FontWeight = FontWeight.SemiBold
+                    Text = "Creato e mantenuto da @pricootz",
+                    FontSize = 18,
+                    FontWeight = FontWeight.SemiBold,
+                    TextWrapping = TextWrapping.Wrap
                 },
-                Description("Nessun account, nessun backend cloud e nessun uploader di telemetria. Le metriche vengono lette sul computer locale.")));
+                Description("EdgePilot è un progetto indipendente open source. Idee, sviluppo, direzione del prodotto e manutenzione principale fanno capo a @pricootz, con contributi della community tramite GitHub."),
+                SegmentRow(new[] { repoButton, profileButton })),
+            Card(
+                SectionTitle("⌁", "Filosofia del progetto"),
+                FeatureRow("◉", "Locale per impostazione predefinita", "Nessun account, nessun backend cloud obbligatorio e nessun uploader di telemetria."),
+                Divider(),
+                FeatureRow("◨", "Edge-native", "EdgePilot vive sul bordo dello schermo e punta a ridurre finestre, dashboard e notifiche tradizionali."),
+                Divider(),
+                FeatureRow("◇", "In evoluzione", "La preview attuale parte dal monitor di sistema; i prossimi moduli allargheranno il concetto senza trasformarlo in un pannello generico.")),
+            Card(
+                SectionTitle("ⓘ", "Versione"),
+                new TextBlock { Text = FullVersionLabel(), FontWeight = FontWeight.SemiBold },
+                Description("Preview in sviluppo attivo. Le API, il layout e alcune funzioni possono ancora cambiare prima della prima release stabile.")));
     }
 
     private ScrollViewer Page(string title, string subtitle, params Control[] sections)
     {
         var stack = new StackPanel
         {
-            Margin = new Thickness(30, 26, 30, 30),
+            Margin = new Thickness(28, 24, 28, 28),
             Spacing = 16
         };
+        _pageStacks.Add(stack);
         stack.Children.Add(new TextBlock
         {
             Text = title,
@@ -529,7 +596,11 @@ public sealed class SettingsWindow : Window
             Margin = new Thickness(0, -8, 0, 8)
         });
         foreach (var section in sections) stack.Children.Add(section);
-        return new ScrollViewer { Content = stack };
+        return new ScrollViewer
+        {
+            Content = stack,
+            HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled
+        };
     }
 
     private Border Card(params Control[] children)
@@ -547,30 +618,69 @@ public sealed class SettingsWindow : Window
         return card;
     }
 
-    private Border MetricTile(CheckBox checkbox, string description)
+    private Border MetricTile(CheckBox checkbox, string icon, string description)
     {
+        var heading = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto"),
+            ColumnSpacing = 9
+        };
+        heading.Children.Add(new TextBlock
+        {
+            Text = icon,
+            FontSize = 18,
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = AccentBrush
+        });
+        var title = new TextBlock
+        {
+            Text = checkbox.Content?.ToString(),
+            FontWeight = FontWeight.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        heading.Children.Add(title);
+        Grid.SetColumn(title, 1);
+        checkbox.Content = null;
+        heading.Children.Add(checkbox);
+        Grid.SetColumn(checkbox, 2);
+
         var tile = new Border
         {
             BorderThickness = new Thickness(1),
             CornerRadius = new CornerRadius(11),
             Padding = new Thickness(14),
+            Cursor = new Cursor(StandardCursorType.Hand),
             Child = new StackPanel
             {
-                Spacing = 6,
+                Spacing = 7,
                 Children =
                 {
-                    checkbox,
+                    heading,
                     Description(description)
                 }
             }
         };
-        _tiles.Add(tile);
+        tile.PointerPressed += (_, e) =>
+        {
+            if (e.Source is CheckBox) return;
+            checkbox.IsChecked = checkbox.IsChecked != true;
+            OnMetricChanged();
+            e.Handled = true;
+        };
         return tile;
     }
 
-    private static TextBlock SectionTitle(string text) => new()
+    private static Control SettingField(string label, Control control)
     {
-        Text = text,
+        var stack = new StackPanel { Spacing = 6 };
+        stack.Children.Add(Label(label));
+        stack.Children.Add(control);
+        return stack;
+    }
+
+    private static TextBlock SectionTitle(string icon, string text) => new()
+    {
+        Text = $"{icon}  {text}",
         FontSize = 16,
         FontWeight = FontWeight.SemiBold
     };
@@ -596,15 +706,78 @@ public sealed class SettingsWindow : Window
         Margin = new Thickness(0, 4)
     };
 
-    private static StackPanel SegmentRow(IEnumerable<Button> buttons)
+    private static WrapPanel SegmentRow(IEnumerable<Button> buttons)
     {
-        var row = new StackPanel
+        var row = new WrapPanel
+        {
+            Orientation = Orientation.Horizontal
+        };
+        foreach (var button in buttons)
+        {
+            button.Margin = new Thickness(0, 0, 8, 8);
+            row.Children.Add(button);
+        }
+        return row;
+    }
+
+    private static WrapPanel ChipRow(params string[] labels)
+    {
+        var row = new WrapPanel { Orientation = Orientation.Horizontal };
+        foreach (var label in labels)
+        {
+            row.Children.Add(new Border
+            {
+                Background = AccentSoftBrush,
+                CornerRadius = new CornerRadius(999),
+                Padding = new Thickness(9, 4),
+                Margin = new Thickness(0, 4, 7, 0),
+                Child = new TextBlock { Text = label, FontSize = 11, FontWeight = FontWeight.SemiBold }
+            });
+        }
+        return row;
+    }
+
+    private static StackPanel FeatureRow(string icon, string title, string description)
+    {
+        return new StackPanel
         {
             Orientation = Orientation.Horizontal,
-            Spacing = 8
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = icon,
+                    FontSize = 18,
+                    Foreground = AccentBrush,
+                    Width = 24,
+                    VerticalAlignment = VerticalAlignment.Top
+                },
+                new StackPanel
+                {
+                    Spacing = 3,
+                    Children =
+                    {
+                        new TextBlock { Text = title, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap },
+                        Description(description)
+                    }
+                }
+            }
         };
-        foreach (var button in buttons) row.Children.Add(button);
-        return row;
+    }
+
+    private static StackPanel ButtonContent(string icon, string text)
+    {
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 7,
+            Children =
+            {
+                new TextBlock { Text = icon, VerticalAlignment = VerticalAlignment.Center },
+                new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center }
+            }
+        };
     }
 
     private static Button SegmentButton(string text, Action select)
@@ -619,19 +792,62 @@ public sealed class SettingsWindow : Window
         return button;
     }
 
-    private Button NavButton(string text, SettingsPage page)
+    private Button NavButton(string icon, string text, SettingsPage page)
     {
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 9,
+            Children =
+            {
+                new TextBlock { Text = icon, Width = 20, TextAlignment = TextAlignment.Center },
+                new TextBlock { Text = text, TextWrapping = TextWrapping.Wrap }
+            }
+        };
         var button = new Button
         {
-            Content = text,
+            Content = content,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             HorizontalContentAlignment = HorizontalAlignment.Left,
-            Padding = new Thickness(12, 10),
+            Padding = new Thickness(11, 10),
             BorderThickness = new Thickness(0)
         };
         button.Click += (_, _) => ShowPage(page);
         _navButtons[page] = button;
         return button;
+    }
+
+    private Button LinkButton(string text, string url)
+    {
+        var button = new Button
+        {
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                Children =
+                {
+                    new PathIcon { Data = Geometry.Parse(GitHubMarkPath), Width = 16, Height = 16 },
+                    new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center }
+                }
+            },
+            Padding = new Thickness(13, 8)
+        };
+        button.Click += (_, _) => OpenUrl(url);
+        return button;
+    }
+
+    private void OpenUrl(string url)
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            System.Diagnostics.Trace.WriteLine(ex);
+            _status.Text = "Impossibile aprire il browser. Visita github.com/pricootz/edgepilot.";
+        }
     }
 
     private void ShowPage(SettingsPage page)
@@ -700,12 +916,38 @@ public sealed class SettingsWindow : Window
         _previewNotch.CornerRadius = new CornerRadius(6);
     }
 
+    private void OnMetricChanged()
+    {
+        UpdateConditionalSettings();
+        UpdateMetricTileStates();
+        MarkDirty();
+    }
+
+    private void UpdateConditionalSettings()
+    {
+        if (_diskCard is not null) _diskCard.IsVisible = _metrics[2].IsChecked == true;
+    }
+
+    private void UpdateMetricTileStates()
+    {
+        if (_metricTiles.Length == 0) return;
+        for (var i = 0; i < _metricTiles.Length; i++)
+        {
+            var selected = _metrics[i].IsChecked == true;
+            _metricTiles[i].Background = selected
+                ? AccentSoftBrush
+                : Brush(_darkTheme ? "#1F1F1F" : "#F8F8F9");
+            _metricTiles[i].BorderBrush = selected
+                ? AccentBrush
+                : Brush(_darkTheme ? "#343434" : "#E6E6E8");
+        }
+    }
+
     private VisibleMetrics SelectedMetrics()
     {
-        var options = new[] { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
         VisibleMetrics selected = 0;
         for (var i = 0; i < _metrics.Length; i++)
-            if (_metrics[i].IsChecked == true) selected |= options[i];
+            if (_metrics[i].IsChecked == true) selected |= MetricOptions[i];
         return selected;
     }
 
@@ -728,8 +970,7 @@ public sealed class SettingsWindow : Window
         var dirty = current != _savedPreferences;
         _applyButton.IsEnabled = dirty;
         _resetButton.IsEnabled = dirty;
-        if (dirty) _status.Text = "Modifiche non salvate.";
-        else _status.Text = "Nessuna modifica da salvare.";
+        _status.Text = dirty ? "Modifiche non salvate." : "Tutto salvato.";
     }
 
     private void ResetToSaved()
@@ -739,8 +980,7 @@ public sealed class SettingsWindow : Window
         _selectedMode = _savedPreferences.Mode;
         _selectedSensitivity = _savedPreferences.Sensitivity;
         _refresh.SelectedIndex = Array.IndexOf(_intervals, _savedPreferences.RefreshIntervalMs);
-        var options = new[] { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
-        for (var i = 0; i < _metrics.Length; i++) _metrics[i].IsChecked = _savedPreferences.Metrics.HasFlag(options[i]);
+        for (var i = 0; i < _metrics.Length; i++) _metrics[i].IsChecked = _savedPreferences.Metrics.HasFlag(MetricOptions[i]);
         _autostart.IsChecked = _savedPreferences.StartAtLogin;
         if (_drive.ItemsSource is IReadOnlyList<DriveChoice> choices)
             _drive.SelectedItem = choices.First(x => DriveSelection.PathComparer.Equals(x.Name, _savedPreferences.SelectedDrive));
@@ -748,6 +988,8 @@ public sealed class SettingsWindow : Window
         UpdateSegments(_modeButtons, (int)_selectedMode);
         UpdateSegments(_sensitivityButtons, (int)_selectedSensitivity);
         UpdatePreview();
+        UpdateConditionalSettings();
+        UpdateMetricTileStates();
         _ready = true;
         _applyButton.IsEnabled = false;
         _resetButton.IsEnabled = false;
@@ -787,30 +1029,72 @@ public sealed class SettingsWindow : Window
         }
     }
 
+    private void ApplyResponsiveLayout(double width)
+    {
+        if (_body is null) return;
+        var compact = width < 800;
+
+        _body.ColumnDefinitions = new ColumnDefinitions(compact ? "154,*" : "184,*");
+        _versionBadge.IsVisible = width >= 760;
+
+        foreach (var stack in _pageStacks)
+            stack.Margin = compact ? new Thickness(18, 20, 18, 24) : new Thickness(28, 24, 28, 28);
+
+        _previewLayout.ColumnDefinitions = compact ? new ColumnDefinitions("*") : new ColumnDefinitions("Auto,*");
+        _previewLayout.RowDefinitions = compact ? new RowDefinitions("Auto,Auto") : new RowDefinitions("Auto");
+        Grid.SetColumn(_positionOptions, compact ? 0 : 1);
+        Grid.SetRow(_positionOptions, compact ? 1 : 0);
+        _positionOptions.Margin = compact ? new Thickness(0, 16, 0, 0) : new Thickness(0);
+        _previewFrame.Width = compact ? 260 : 292;
+        _previewFrame.Height = compact ? 158 : 178;
+
+        _metricGrid.ColumnDefinitions = compact ? new ColumnDefinitions("*") : new ColumnDefinitions("*,*");
+        _metricGrid.RowDefinitions = compact
+            ? new RowDefinitions("Auto,Auto,Auto,Auto")
+            : new RowDefinitions("Auto,Auto");
+        for (var i = 0; i < _metricTiles.Length; i++)
+        {
+            Grid.SetColumn(_metricTiles[i], compact ? 0 : i % 2);
+            Grid.SetRow(_metricTiles[i], compact ? i : i / 2);
+        }
+    }
+
     private void ApplyTheme()
     {
-        var dark = ActualThemeVariant == ThemeVariant.Dark;
-        Background = Brush(dark ? "#121212" : "#F4F4F5");
-        _header.Background = Brush(dark ? "#151515" : "#FFFFFF");
-        _sidebar.Background = Brush(dark ? "#141414" : "#FAFAFA");
-        _footer.Background = Brush(dark ? "#151515" : "#FFFFFF");
+        _darkTheme = ActualThemeVariant == ThemeVariant.Dark;
+        Background = Brush(_darkTheme ? "#121212" : "#F4F4F5");
+        _header.Background = Brush(_darkTheme ? "#151515" : "#FFFFFF");
+        _sidebar.Background = Brush(_darkTheme ? "#141414" : "#FAFAFA");
+        _footer.Background = Brush(_darkTheme ? "#151515" : "#FFFFFF");
 
-        var line = Brush(dark ? "#2C2C2C" : "#DDDDDF");
+        var line = Brush(_darkTheme ? "#2C2C2C" : "#DDDDDF");
         _header.BorderBrush = line;
         _sidebar.BorderBrush = line;
         _footer.BorderBrush = line;
 
         foreach (var card in _cards)
         {
-            card.Background = Brush(dark ? "#191919" : "#FFFFFF");
-            card.BorderBrush = Brush(dark ? "#2D2D2D" : "#E2E2E4");
+            card.Background = Brush(_darkTheme ? "#191919" : "#FFFFFF");
+            card.BorderBrush = Brush(_darkTheme ? "#2D2D2D" : "#E2E2E4");
         }
-        foreach (var tile in _tiles)
-        {
-            tile.Background = Brush(dark ? "#1F1F1F" : "#F8F8F9");
-            tile.BorderBrush = Brush(dark ? "#343434" : "#E6E6E8");
-        }
+        UpdateMetricTileStates();
         ShowPage(_selectedPage);
+    }
+
+    private static string VersionLabel()
+    {
+        var version = FullVersionLabel();
+        if (version.Contains("0.2", StringComparison.OrdinalIgnoreCase)) return "PREVIEW 0.2";
+        return version.ToUpperInvariant();
+    }
+
+    private static string FullVersionLabel()
+    {
+        var informational = typeof(SettingsWindow).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion?
+            .Split('+')[0];
+        return string.IsNullOrWhiteSpace(informational) ? "Preview" : $"v{informational}";
     }
 
     private static IBrush Brush(string color) => new SolidColorBrush(Color.Parse(color));

--- a/src/EdgePilot/UI/SettingsWindow.cs
+++ b/src/EdgePilot/UI/SettingsWindow.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
@@ -9,8 +8,13 @@ using EdgePilot.Core;
 
 namespace EdgePilot.UI;
 
-public sealed class SettingsWindow : Window
+public sealed partial class SettingsWindow : Window
 {
+    private sealed record LanguageChoice(Language? Value, string Caption)
+    {
+        public override string ToString() => Caption;
+    }
+
     private static readonly IBrush AccentBrush = new SolidColorBrush(Color.Parse("#FF8A3D"));
     private static readonly IBrush AccentSoftBrush = new SolidColorBrush(Color.FromArgb(38, 255, 138, 61));
     private static readonly IBrush PreviewBackgroundBrush = new SolidColorBrush(Color.Parse("#101114"));
@@ -19,11 +23,9 @@ public sealed class SettingsWindow : Window
     private static readonly VisibleMetrics[] MetricOptions =
         { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
 
-    private const string GitHubMarkPath =
-        "M6.766 11.328c-2.063-.25-3.516-1.734-3.516-3.656 0-.781.281-1.625.75-2.188-.203-.515-.172-1.609.063-2.062.625-.078 1.468.25 1.968.703.594-.187 1.219-.281 1.985-.281.765 0 1.39.094 1.953.265.484-.437 1.344-.765 1.969-.687.218.422.25 1.515.046 2.047.5.593.766 1.39.766 2.203 0 1.922-1.453 3.375-3.547 3.64.531.344.89 1.094.89 1.954v1.625c0 .468.391.734.86.547C13.781 14.359 16 11.53 16 8.03 16 3.61 12.406 0 7.984 0 3.563 0 0 3.61 0 8.031a7.88 7.88 0 0 0 5.172 7.422c.422.156.828-.125.828-.547v-1.25c-.219.094-.5.156-.75.156-1.031 0-1.64-.562-2.078-1.609-.172-.422-.36-.672-.719-.719-.187-.015-.25-.093-.25-.187 0-.188.313-.328.625-.328.453 0 .844.281 1.25.86.313.452.64.655 1.031.655s.641-.14 1-.5c.266-.265.47-.5.657-.656";
-
     private readonly ComboBox _drive;
     private readonly ComboBox _refresh;
+    private readonly ComboBox _language;
     private readonly CheckBox[] _metrics;
     private readonly CheckBox _autostart;
     private readonly Button _applyButton;
@@ -61,9 +63,10 @@ public sealed class SettingsWindow : Window
     private bool _ready;
     private bool _darkTheme;
 
-    public SettingsWindow(NotchPreferences current, Action<NotchPreferences> apply, string? warning = null, string? storagePath = null,
-        IReadOnlyList<DriveSnapshot>? drives = null, Action<NotchPreferences>? savePreferences = null,
-        Action? exit = null, bool hasTray = false)
+    public SettingsWindow(NotchPreferences current, Action<NotchPreferences> apply, string? warning = null,
+        string? storagePath = null, IReadOnlyList<DriveSnapshot>? drives = null,
+        Action<NotchPreferences>? savePreferences = null, Action? exit = null, bool hasTray = false,
+        Action? reopen = null)
     {
         _savedPreferences = current;
         _selectedEdge = current.Edge;
@@ -71,7 +74,7 @@ public sealed class SettingsWindow : Window
         _selectedSensitivity = current.Sensitivity;
         _initialDrive = current.SelectedDrive;
 
-        Title = "EdgePilot · Impostazioni";
+        Title = Localization.T("settings.title");
         Icon = AppIcon.Load();
         Width = 920;
         Height = 680;
@@ -91,14 +94,38 @@ public sealed class SettingsWindow : Window
 
         _refresh = new ComboBox
         {
-            ItemsSource = new[] { "Ogni 0,5 secondi", "Ogni secondo", "Ogni 2 secondi", "Ogni 5 secondi" },
+            ItemsSource = new[]
+            {
+                Localization.T("refresh.0_5s"), Localization.T("refresh.1s"),
+                Localization.T("refresh.2s"), Localization.T("refresh.5s")
+            },
             SelectedIndex = Array.IndexOf(_intervals, current.RefreshIntervalMs),
             HorizontalAlignment = HorizontalAlignment.Left,
             MaxWidth = 320,
             MinWidth = 210
         };
 
-        var metricNames = new[] { "CPU", "Memoria", "Disco", "Rete" };
+        var languageChoices = new[]
+        {
+            new LanguageChoice(null, Localization.T("language.auto")),
+            new LanguageChoice(Language.Italian, "Italiano"),
+            new LanguageChoice(Language.English, "English"),
+            new LanguageChoice(Language.French, "Français")
+        };
+        _language = new ComboBox
+        {
+            ItemsSource = languageChoices,
+            SelectedIndex = Array.FindIndex(languageChoices, x => x.Value == current.Language),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            MinWidth = 210,
+            MaxWidth = 320
+        };
+
+        var metricNames = new[]
+        {
+            Localization.T("metric.cpu"), Localization.T("metric.memory"),
+            Localization.T("metric.disk"), Localization.T("metric.network")
+        };
         _metrics = MetricOptions.Select((flag, index) => new CheckBox
         {
             Content = metricNames[index],
@@ -109,7 +136,7 @@ public sealed class SettingsWindow : Window
 
         _autostart = new CheckBox
         {
-            Content = "Avvia EdgePilot quando accedo al sistema",
+            Content = Localization.T("startup.autostartLabel"),
             IsChecked = current.StartAtLogin,
             FontWeight = FontWeight.SemiBold
         };
@@ -144,29 +171,29 @@ public sealed class SettingsWindow : Window
 
         _edgeButtons =
         [
-            SegmentButton("▸  Destra", () => SelectEdge(EdgeSide.Right)),
-            SegmentButton("◂  Sinistra", () => SelectEdge(EdgeSide.Left)),
-            SegmentButton("▴  Alto", () => SelectEdge(EdgeSide.Top)),
-            SegmentButton("▾  Basso", () => SelectEdge(EdgeSide.Bottom))
+            SegmentButton("▸", Localization.T("edge.right"), () => SelectEdge(EdgeSide.Right)),
+            SegmentButton("◂", Localization.T("edge.left"), () => SelectEdge(EdgeSide.Left)),
+            SegmentButton("▴", Localization.T("edge.top"), () => SelectEdge(EdgeSide.Top)),
+            SegmentButton("▾", Localization.T("edge.bottom"), () => SelectEdge(EdgeSide.Bottom))
         ];
 
         _modeButtons =
         [
-            SegmentButton("◌  Al passaggio", () => SelectMode(NotchDisplayMode.Hover)),
-            SegmentButton("●  Sempre visibile", () => SelectMode(NotchDisplayMode.Always)),
-            SegmentButton("○  Nascosto", () => SelectMode(NotchDisplayMode.Hidden))
+            SegmentButton("◌", Localization.T("mode.hover"), () => SelectMode(NotchDisplayMode.Hover)),
+            SegmentButton("●", Localization.T("mode.always"), () => SelectMode(NotchDisplayMode.Always)),
+            SegmentButton("○", Localization.T("mode.hidden"), () => SelectMode(NotchDisplayMode.Hidden))
         ];
 
         _sensitivityButtons =
         [
-            SegmentButton("Precisa", () => SelectSensitivity(HoverSensitivity.Precise)),
-            SegmentButton("Normale", () => SelectSensitivity(HoverSensitivity.Normal)),
-            SegmentButton("Ampia", () => SelectSensitivity(HoverSensitivity.Wide))
+            SegmentButton(null, Localization.T("sensitivity.precise"), () => SelectSensitivity(HoverSensitivity.Precise)),
+            SegmentButton(null, Localization.T("sensitivity.normal"), () => SelectSensitivity(HoverSensitivity.Normal)),
+            SegmentButton(null, Localization.T("sensitivity.wide"), () => SelectSensitivity(HoverSensitivity.Wide))
         ];
 
         _status = new TextBlock
         {
-            Text = warning ?? "Tutto salvato.",
+            Text = warning ?? Localization.T("settings.status.saved"),
             TextWrapping = TextWrapping.Wrap,
             VerticalAlignment = VerticalAlignment.Center,
             MaxLines = 2
@@ -174,7 +201,7 @@ public sealed class SettingsWindow : Window
 
         _applyButton = new Button
         {
-            Content = ButtonContent("✓", "Salva modifiche"),
+            Content = ButtonContent("✓", Localization.T("settings.saveChanges")),
             Background = AccentBrush,
             Padding = new Thickness(17, 9),
             MinWidth = 146,
@@ -182,7 +209,7 @@ public sealed class SettingsWindow : Window
         };
         _resetButton = new Button
         {
-            Content = ButtonContent("↶", "Annulla"),
+            Content = ButtonContent("↶", Localization.T("settings.resetChanges")),
             Padding = new Thickness(14, 9),
             MinWidth = 100,
             IsEnabled = false
@@ -190,11 +217,12 @@ public sealed class SettingsWindow : Window
 
         _drive.SelectionChanged += (_, _) => MarkDirty();
         _refresh.SelectionChanged += (_, _) => MarkDirty();
+        _language.SelectionChanged += (_, _) => MarkDirty();
         foreach (var metric in _metrics) metric.Click += (_, _) => OnMetricChanged();
         _autostart.Click += (_, _) => MarkDirty();
 
         _resetButton.Click += (_, _) => ResetToSaved();
-        _applyButton.Click += (_, _) => SaveChanges(apply, savePreferences, storagePath, hasTray);
+        _applyButton.Click += (_, _) => SaveChanges(apply, savePreferences, storagePath, hasTray, reopen);
 
         _pageHost = new ContentControl
         {
@@ -255,599 +283,6 @@ public sealed class SettingsWindow : Window
         if (_drive is null) return;
         _drive.ItemsSource = choices;
         _drive.SelectedItem = choices.First(x => DriveSelection.PathComparer.Equals(x.Name, selected));
-    }
-
-    private Border BuildHeader()
-    {
-        var title = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 12,
-            VerticalAlignment = VerticalAlignment.Center,
-            Children =
-            {
-                new EdgePilotLogo { Width = 36, Height = 36 },
-                new StackPanel
-                {
-                    Spacing = 1,
-                    Children =
-                    {
-                        new TextBlock { Text = "EdgePilot", FontSize = 20, FontWeight = FontWeight.SemiBold },
-                        new TextBlock { Text = "Impostazioni", FontSize = 12, Foreground = MutedBrush }
-                    }
-                }
-            }
-        };
-
-        _versionBadge = new Border
-        {
-            Background = AccentSoftBrush,
-            BorderBrush = AccentBrush,
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(999),
-            Padding = new Thickness(10, 4),
-            VerticalAlignment = VerticalAlignment.Center,
-            Child = new TextBlock
-            {
-                Text = VersionLabel(),
-                FontSize = 10,
-                FontWeight = FontWeight.SemiBold
-            }
-        };
-
-        var grid = new Grid
-        {
-            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
-            Margin = new Thickness(24, 0)
-        };
-        grid.Children.Add(title);
-        grid.Children.Add(_versionBadge);
-        Grid.SetColumn(_versionBadge, 1);
-
-        return new Border
-        {
-            BorderThickness = new Thickness(0, 0, 0, 1),
-            Child = grid
-        };
-    }
-
-    private Border BuildSidebar()
-    {
-        var nav = new StackPanel
-        {
-            Spacing = 4,
-            Margin = new Thickness(12, 18)
-        };
-        nav.Children.Add(new TextBlock
-        {
-            Text = "IMPOSTAZIONI",
-            FontSize = 10,
-            FontWeight = FontWeight.SemiBold,
-            Foreground = MutedBrush,
-            Margin = new Thickness(10, 0, 0, 8)
-        });
-        nav.Children.Add(NavButton("◨", "Bordo", SettingsPage.Edge));
-        nav.Children.Add(NavButton("▦", "Monitor", SettingsPage.Monitor));
-        nav.Children.Add(NavButton("⚙", "Comportamento", SettingsPage.Behavior));
-        nav.Children.Add(NavButton("↻", "Avvio", SettingsPage.Startup));
-        nav.Children.Add(NavButton("ⓘ", "Informazioni", SettingsPage.About));
-
-        return new Border
-        {
-            BorderThickness = new Thickness(0, 0, 1, 0),
-            Child = nav
-        };
-    }
-
-    private Border BuildFooter()
-    {
-        var statusDot = new Border
-        {
-            Width = 7,
-            Height = 7,
-            Background = AccentBrush,
-            CornerRadius = new CornerRadius(4),
-            VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 9, 0)
-        };
-        var statusRow = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Center,
-            Children = { statusDot, _status }
-        };
-
-        var actions = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 8,
-            VerticalAlignment = VerticalAlignment.Center,
-            Children = { _resetButton, _applyButton }
-        };
-
-        var grid = new Grid
-        {
-            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
-            Margin = new Thickness(24, 0)
-        };
-        grid.Children.Add(statusRow);
-        grid.Children.Add(actions);
-        Grid.SetColumn(actions, 1);
-
-        return new Border
-        {
-            BorderThickness = new Thickness(0, 1, 0, 0),
-            Child = grid
-        };
-    }
-
-    private Control BuildEdgePage()
-    {
-        _positionOptions = new StackPanel
-        {
-            Spacing = 10,
-            VerticalAlignment = VerticalAlignment.Center,
-            Children =
-            {
-                Label("Posizione"),
-                Description("Scegli il bordo da cui EdgePilot deve emergere."),
-                SegmentRow(_edgeButtons)
-            }
-        };
-
-        _previewLayout = new Grid
-        {
-            ColumnDefinitions = new ColumnDefinitions("Auto,*"),
-            RowDefinitions = new RowDefinitions("Auto"),
-            ColumnSpacing = 24
-        };
-        _previewLayout.Children.Add(_previewFrame);
-        _previewLayout.Children.Add(_positionOptions);
-        Grid.SetColumn(_positionOptions, 1);
-
-        return Page(
-            "Bordo e presenza",
-            "Definisci dove vive EdgePilot e quanto deve essere presente sul desktop.",
-            Card(
-                SectionTitle("◨", "Posizione sullo schermo"),
-                Description("La preview cambia insieme alla scelta e mostra dove comparirà la linguetta."),
-                _previewLayout),
-            Card(
-                SectionTitle("◌", "Comportamento del pannello"),
-                Description("Al passaggio mantiene EdgePilot discreto. Sempre visibile lo lascia aperto. Nascosto lo rimuove dal bordo finché non lo riapri dalla tray o dalle impostazioni."),
-                SegmentRow(_modeButtons)));
-    }
-
-    private Control BuildMonitorPage()
-    {
-        _metricGrid = new Grid
-        {
-            ColumnDefinitions = new ColumnDefinitions("*,*"),
-            RowDefinitions = new RowDefinitions("Auto,Auto"),
-            ColumnSpacing = 12,
-            RowSpacing = 12
-        };
-
-        var descriptions = new[]
-        {
-            "Carico del processore in tempo reale",
-            "Memoria RAM attualmente utilizzata",
-            "Spazio occupato sul volume scelto",
-            "Traffico di download e upload"
-        };
-        var icons = new[] { "◉", "▤", "▱", "↕" };
-        _metricTiles = new Border[_metrics.Length];
-        for (var i = 0; i < _metrics.Length; i++)
-        {
-            var tile = MetricTile(_metrics[i], icons[i], descriptions[i]);
-            _metricTiles[i] = tile;
-            _metricGrid.Children.Add(tile);
-            Grid.SetColumn(tile, i % 2);
-            Grid.SetRow(tile, i / 2);
-        }
-
-        _diskCard = Card(
-            SectionTitle("▱", "Volume per la metrica Disco"),
-            Description("Questa scelta compare solo quando la metrica Disco è attiva. EdgePilot conserva comunque la selezione se la disattivi temporaneamente."),
-            _drive);
-
-        return Page(
-            "Monitor di sistema",
-            "Decidi quali dati del modulo System devono comparire nella notch.",
-            Card(
-                SectionTitle("▦", "Metriche visibili"),
-                Description("Fai clic sull’intera scheda per attivare o disattivare una metrica. La notch si ridimensiona automaticamente."),
-                _metricGrid),
-            _diskCard);
-    }
-
-    private Control BuildBehaviorPage()
-    {
-        return Page(
-            "Comportamento",
-            "Regola quanto spesso EdgePilot aggiorna i dati e quanto facilmente reagisce al bordo.",
-            Card(
-                SectionTitle("↻", "Frequenza di aggiornamento"),
-                Description("Un intervallo breve rende i valori più reattivi. Un intervallo più lungo riduce leggermente il lavoro in background."),
-                SettingField("Aggiorna i dati", _refresh)),
-            Card(
-                SectionTitle("◎", "Sensibilità al bordo"),
-                Description("Precisa richiede di arrivare vicino alla linguetta. Ampia crea una zona di aggancio più generosa. Normale è il compromesso consigliato."),
-                SegmentRow(_sensitivityButtons)));
-    }
-
-    private Control BuildStartupPage(Action? exit)
-    {
-        var exitButton = new Button
-        {
-            Content = ButtonContent("⏻", "Esci da EdgePilot"),
-            HorizontalAlignment = HorizontalAlignment.Left,
-            Padding = new Thickness(14, 8)
-        };
-        exitButton.Click += (_, _) =>
-        {
-            if (exit is not null) exit();
-            else Close();
-        };
-
-        return Page(
-            "Avvio e sessione",
-            "Scegli come EdgePilot entra nella sessione e quando deve terminare completamente.",
-            Card(
-                SectionTitle("↻", "Avvio automatico"),
-                Description("Abilita l’avvio per l’utente corrente. EdgePilot resterà disponibile senza doverlo lanciare manualmente a ogni accesso."),
-                _autostart),
-            Card(
-                SectionTitle("⏻", "Sessione corrente"),
-                Description("Chiude completamente EdgePilot, inclusi pannello e processo in background."),
-                exitButton));
-    }
-
-    private Control BuildAboutPage()
-    {
-        var hero = new Grid
-        {
-            ColumnDefinitions = new ColumnDefinitions("Auto,*"),
-            ColumnSpacing = 20
-        };
-        var logo = new EdgePilotLogo
-        {
-            Width = 76,
-            Height = 76,
-            VerticalAlignment = VerticalAlignment.Top
-        };
-        hero.Children.Add(logo);
-
-        var heroText = new StackPanel
-        {
-            Spacing = 6,
-            Children =
-            {
-                new TextBlock
-                {
-                    Text = "EdgePilot",
-                    FontSize = 28,
-                    FontWeight = FontWeight.SemiBold
-                },
-                new TextBlock
-                {
-                    Text = "Your desktop has edges. EdgePilot makes them useful.",
-                    FontSize = 16,
-                    TextWrapping = TextWrapping.Wrap
-                },
-                Description("Una superficie desktop edge-native per Windows e Linux, progettata per mostrare informazioni e azioni solo quando servono."),
-                ChipRow("Open source", "MIT", "Windows + Linux", "Local-first")
-            }
-        };
-        hero.Children.Add(heroText);
-        Grid.SetColumn(heroText, 1);
-
-        var repoButton = LinkButton("Repository GitHub", "https://github.com/pricootz/edgepilot");
-        var profileButton = LinkButton("Profilo @pricootz", "https://github.com/pricootz");
-
-        return Page(
-            "Informazioni",
-            "Il progetto, chi lo sviluppa e i principi su cui viene costruito.",
-            Card(hero),
-            Card(
-                SectionTitle("✦", "Autore"),
-                new TextBlock
-                {
-                    Text = "Creato e mantenuto da @pricootz",
-                    FontSize = 18,
-                    FontWeight = FontWeight.SemiBold,
-                    TextWrapping = TextWrapping.Wrap
-                },
-                Description("EdgePilot è un progetto indipendente open source. Idee, sviluppo, direzione del prodotto e manutenzione principale fanno capo a @pricootz, con contributi della community tramite GitHub."),
-                SegmentRow(new[] { repoButton, profileButton })),
-            Card(
-                SectionTitle("⌁", "Filosofia del progetto"),
-                FeatureRow("◉", "Locale per impostazione predefinita", "Nessun account, nessun backend cloud obbligatorio e nessun uploader di telemetria."),
-                Divider(),
-                FeatureRow("◨", "Edge-native", "EdgePilot vive sul bordo dello schermo e punta a ridurre finestre, dashboard e notifiche tradizionali."),
-                Divider(),
-                FeatureRow("◇", "In evoluzione", "La preview attuale parte dal monitor di sistema; i prossimi moduli allargheranno il concetto senza trasformarlo in un pannello generico.")),
-            Card(
-                SectionTitle("ⓘ", "Versione"),
-                new TextBlock { Text = FullVersionLabel(), FontWeight = FontWeight.SemiBold },
-                Description("Preview in sviluppo attivo. Le API, il layout e alcune funzioni possono ancora cambiare prima della prima release stabile.")));
-    }
-
-    private ScrollViewer Page(string title, string subtitle, params Control[] sections)
-    {
-        var stack = new StackPanel
-        {
-            Margin = new Thickness(28, 24, 28, 28),
-            Spacing = 16
-        };
-        _pageStacks.Add(stack);
-        stack.Children.Add(new TextBlock
-        {
-            Text = title,
-            FontSize = 28,
-            FontWeight = FontWeight.SemiBold
-        });
-        stack.Children.Add(new TextBlock
-        {
-            Text = subtitle,
-            Foreground = MutedBrush,
-            FontSize = 14,
-            TextWrapping = TextWrapping.Wrap,
-            Margin = new Thickness(0, -8, 0, 8)
-        });
-        foreach (var section in sections) stack.Children.Add(section);
-        return new ScrollViewer
-        {
-            Content = stack,
-            HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled
-        };
-    }
-
-    private Border Card(params Control[] children)
-    {
-        var stack = new StackPanel { Spacing = 12 };
-        foreach (var child in children) stack.Children.Add(child);
-        var card = new Border
-        {
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(14),
-            Padding = new Thickness(18),
-            Child = stack
-        };
-        _cards.Add(card);
-        return card;
-    }
-
-    private Border MetricTile(CheckBox checkbox, string icon, string description)
-    {
-        var heading = new Grid
-        {
-            ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto"),
-            ColumnSpacing = 9
-        };
-        heading.Children.Add(new TextBlock
-        {
-            Text = icon,
-            FontSize = 18,
-            VerticalAlignment = VerticalAlignment.Center,
-            Foreground = AccentBrush
-        });
-        var title = new TextBlock
-        {
-            Text = checkbox.Content?.ToString(),
-            FontWeight = FontWeight.SemiBold,
-            VerticalAlignment = VerticalAlignment.Center
-        };
-        heading.Children.Add(title);
-        Grid.SetColumn(title, 1);
-        checkbox.Content = null;
-        heading.Children.Add(checkbox);
-        Grid.SetColumn(checkbox, 2);
-
-        var tile = new Border
-        {
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(11),
-            Padding = new Thickness(14),
-            Cursor = new Cursor(StandardCursorType.Hand),
-            Child = new StackPanel
-            {
-                Spacing = 7,
-                Children =
-                {
-                    heading,
-                    Description(description)
-                }
-            }
-        };
-        tile.PointerPressed += (_, e) =>
-        {
-            if (e.Source is CheckBox) return;
-            checkbox.IsChecked = checkbox.IsChecked != true;
-            OnMetricChanged();
-            e.Handled = true;
-        };
-        return tile;
-    }
-
-    private static Control SettingField(string label, Control control)
-    {
-        var stack = new StackPanel { Spacing = 6 };
-        stack.Children.Add(Label(label));
-        stack.Children.Add(control);
-        return stack;
-    }
-
-    private static TextBlock SectionTitle(string icon, string text) => new()
-    {
-        Text = $"{icon}  {text}",
-        FontSize = 16,
-        FontWeight = FontWeight.SemiBold
-    };
-
-    private static TextBlock Label(string text) => new()
-    {
-        Text = text,
-        FontWeight = FontWeight.SemiBold
-    };
-
-    private static TextBlock Description(string text) => new()
-    {
-        Text = text,
-        Foreground = MutedBrush,
-        FontSize = 12,
-        TextWrapping = TextWrapping.Wrap
-    };
-
-    private static Border Divider() => new()
-    {
-        Height = 1,
-        Background = new SolidColorBrush(Color.FromArgb(60, 128, 128, 128)),
-        Margin = new Thickness(0, 4)
-    };
-
-    private static WrapPanel SegmentRow(IEnumerable<Button> buttons)
-    {
-        var row = new WrapPanel
-        {
-            Orientation = Orientation.Horizontal
-        };
-        foreach (var button in buttons)
-        {
-            button.Margin = new Thickness(0, 0, 8, 8);
-            row.Children.Add(button);
-        }
-        return row;
-    }
-
-    private static WrapPanel ChipRow(params string[] labels)
-    {
-        var row = new WrapPanel { Orientation = Orientation.Horizontal };
-        foreach (var label in labels)
-        {
-            row.Children.Add(new Border
-            {
-                Background = AccentSoftBrush,
-                CornerRadius = new CornerRadius(999),
-                Padding = new Thickness(9, 4),
-                Margin = new Thickness(0, 4, 7, 0),
-                Child = new TextBlock { Text = label, FontSize = 11, FontWeight = FontWeight.SemiBold }
-            });
-        }
-        return row;
-    }
-
-    private static StackPanel FeatureRow(string icon, string title, string description)
-    {
-        return new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 12,
-            Children =
-            {
-                new TextBlock
-                {
-                    Text = icon,
-                    FontSize = 18,
-                    Foreground = AccentBrush,
-                    Width = 24,
-                    VerticalAlignment = VerticalAlignment.Top
-                },
-                new StackPanel
-                {
-                    Spacing = 3,
-                    Children =
-                    {
-                        new TextBlock { Text = title, FontWeight = FontWeight.SemiBold, TextWrapping = TextWrapping.Wrap },
-                        Description(description)
-                    }
-                }
-            }
-        };
-    }
-
-    private static StackPanel ButtonContent(string icon, string text)
-    {
-        return new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 7,
-            Children =
-            {
-                new TextBlock { Text = icon, VerticalAlignment = VerticalAlignment.Center },
-                new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center }
-            }
-        };
-    }
-
-    private static Button SegmentButton(string text, Action select)
-    {
-        var button = new Button
-        {
-            Content = text,
-            Padding = new Thickness(13, 8),
-            MinWidth = 72
-        };
-        button.Click += (_, _) => select();
-        return button;
-    }
-
-    private Button NavButton(string icon, string text, SettingsPage page)
-    {
-        var content = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 9,
-            Children =
-            {
-                new TextBlock { Text = icon, Width = 20, TextAlignment = TextAlignment.Center },
-                new TextBlock { Text = text, TextWrapping = TextWrapping.Wrap }
-            }
-        };
-        var button = new Button
-        {
-            Content = content,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            HorizontalContentAlignment = HorizontalAlignment.Left,
-            Padding = new Thickness(11, 10),
-            BorderThickness = new Thickness(0)
-        };
-        button.Click += (_, _) => ShowPage(page);
-        _navButtons[page] = button;
-        return button;
-    }
-
-    private Button LinkButton(string text, string url)
-    {
-        var button = new Button
-        {
-            Content = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                Spacing = 8,
-                Children =
-                {
-                    new PathIcon { Data = Geometry.Parse(GitHubMarkPath), Width = 16, Height = 16 },
-                    new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center }
-                }
-            },
-            Padding = new Thickness(13, 8)
-        };
-        button.Click += (_, _) => OpenUrl(url);
-        return button;
-    }
-
-    private void OpenUrl(string url)
-    {
-        try
-        {
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
-        {
-            System.Diagnostics.Trace.WriteLine(ex);
-            _status.Text = "Impossibile aprire il browser. Visita github.com/pricootz/edgepilot.";
-        }
     }
 
     private void ShowPage(SettingsPage page)
@@ -959,7 +394,8 @@ public sealed class SettingsWindow : Window
             Sensitivity = _selectedSensitivity,
             Metrics = SelectedMetrics(),
             SelectedDrive = (_drive.SelectedItem as DriveChoice)?.Name,
-            StartAtLogin = _autostart.IsChecked == true
+            StartAtLogin = _autostart.IsChecked == true,
+            Language = (_language.SelectedItem as LanguageChoice)?.Value
         };
     }
 
@@ -970,7 +406,7 @@ public sealed class SettingsWindow : Window
         var dirty = current != _savedPreferences;
         _applyButton.IsEnabled = dirty;
         _resetButton.IsEnabled = dirty;
-        _status.Text = dirty ? "Modifiche non salvate." : "Tutto salvato.";
+        _status.Text = dirty ? Localization.T("settings.status.unsaved") : Localization.T("settings.status.saved");
     }
 
     private void ResetToSaved()
@@ -980,10 +416,15 @@ public sealed class SettingsWindow : Window
         _selectedMode = _savedPreferences.Mode;
         _selectedSensitivity = _savedPreferences.Sensitivity;
         _refresh.SelectedIndex = Array.IndexOf(_intervals, _savedPreferences.RefreshIntervalMs);
-        for (var i = 0; i < _metrics.Length; i++) _metrics[i].IsChecked = _savedPreferences.Metrics.HasFlag(MetricOptions[i]);
+        for (var i = 0; i < _metrics.Length; i++)
+            _metrics[i].IsChecked = _savedPreferences.Metrics.HasFlag(MetricOptions[i]);
         _autostart.IsChecked = _savedPreferences.StartAtLogin;
+
+        if (_language.ItemsSource is IReadOnlyList<LanguageChoice> languages)
+            _language.SelectedItem = languages.First(x => x.Value == _savedPreferences.Language);
         if (_drive.ItemsSource is IReadOnlyList<DriveChoice> choices)
             _drive.SelectedItem = choices.First(x => DriveSelection.PathComparer.Equals(x.Name, _savedPreferences.SelectedDrive));
+
         UpdateSegments(_edgeButtons, (int)_selectedEdge);
         UpdateSegments(_modeButtons, (int)_selectedMode);
         UpdateSegments(_sensitivityButtons, (int)_selectedSensitivity);
@@ -993,20 +434,22 @@ public sealed class SettingsWindow : Window
         _ready = true;
         _applyButton.IsEnabled = false;
         _resetButton.IsEnabled = false;
-        _status.Text = "Modifiche annullate.";
+        _status.Text = Localization.T("settings.status.reset");
     }
 
-    private void SaveChanges(Action<NotchPreferences> apply, Action<NotchPreferences>? savePreferences, string? storagePath, bool hasTray)
+    private void SaveChanges(Action<NotchPreferences> apply, Action<NotchPreferences>? savePreferences,
+        string? storagePath, bool hasTray, Action? reopen)
     {
         var selectedMetrics = SelectedMetrics();
         if (selectedMetrics == 0)
         {
-            _status.Text = "Seleziona almeno una metrica da mostrare.";
+            _status.Text = Localization.T("settings.selectMetric");
             ShowPage(SettingsPage.Monitor);
             return;
         }
 
         var value = CurrentPreferences();
+        var languageChanged = value.Language != _savedPreferences.Language;
         try
         {
             if (savePreferences is not null) savePreferences(value);
@@ -1015,16 +458,22 @@ public sealed class SettingsWindow : Window
             _savedPreferences = value;
             _applyButton.IsEnabled = false;
             _resetButton.IsEnabled = false;
+
+            if (languageChanged && reopen is not null)
+            {
+                reopen();
+                Close();
+                return;
+            }
+
             _status.Text = value.Mode == NotchDisplayMode.Hidden
-                ? (hasTray
-                    ? "Pannello nascosto. Puoi riaprirlo dall’area di notifica."
-                    : "Pannello nascosto. Chiudendo le impostazioni esci da EdgePilot; al prossimo avvio tornerai qui.")
-                : "Impostazioni salvate.";
+                ? (hasTray ? Localization.T("settings.hiddenWithTray") : Localization.T("settings.hiddenNoTray"))
+                : Localization.T("settings.saved");
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or System.Security.SecurityException)
         {
             System.Diagnostics.Trace.WriteLine(ex);
-            _status.Text = "Impossibile salvare le impostazioni. Verifica permessi e spazio disponibile, poi riprova.";
+            _status.Text = Localization.T("settings.saveFailed");
             _applyButton.IsEnabled = true;
         }
     }

--- a/src/EdgePilot/UI/SettingsWindow.cs
+++ b/src/EdgePilot/UI/SettingsWindow.cs
@@ -1,148 +1,826 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Styling;
 using EdgePilot.Core;
 
 namespace EdgePilot.UI;
 
 public sealed class SettingsWindow : Window
 {
+    private static readonly IBrush AccentBrush = new SolidColorBrush(Color.Parse("#FF8A3D"));
+    private static readonly IBrush AccentSoftBrush = new SolidColorBrush(Color.FromArgb(38, 255, 138, 61));
+    private static readonly IBrush PreviewBackgroundBrush = new SolidColorBrush(Color.Parse("#101114"));
+    private static readonly IBrush PreviewBorderBrush = new SolidColorBrush(Color.Parse("#404247"));
+    private static readonly IBrush MutedBrush = new SolidColorBrush(Color.Parse("#8D9096"));
+
     private readonly ComboBox _drive;
+    private readonly ComboBox _refresh;
+    private readonly CheckBox[] _metrics;
+    private readonly CheckBox _autostart;
+    private readonly Button _applyButton;
+    private readonly Button _resetButton;
+    private readonly TextBlock _status;
+    private readonly ContentControl _pageHost;
+    private readonly Border _header;
+    private readonly Border _sidebar;
+    private readonly Border _footer;
+    private readonly Border _previewFrame;
+    private readonly Border _previewNotch;
+    private readonly Button[] _edgeButtons;
+    private readonly Button[] _modeButtons;
+    private readonly Button[] _sensitivityButtons;
+    private readonly Dictionary<SettingsPage, Button> _navButtons = new();
+    private readonly Dictionary<SettingsPage, Control> _pages = new();
+    private readonly List<Border> _cards = new();
+    private readonly List<Border> _tiles = new();
     private readonly string? _initialDrive;
+    private readonly int[] _intervals = { 500, 1000, 2000, 5000 };
+
+    private NotchPreferences _savedPreferences;
+    private EdgeSide _selectedEdge;
+    private NotchDisplayMode _selectedMode;
+    private HoverSensitivity _selectedSensitivity;
+    private SettingsPage _selectedPage;
+    private bool _ready;
+
     public SettingsWindow(NotchPreferences current, Action<NotchPreferences> apply, string? warning = null, string? storagePath = null,
         IReadOnlyList<DriveSnapshot>? drives = null, Action<NotchPreferences>? savePreferences = null,
         Action? exit = null, bool hasTray = false)
     {
+        _savedPreferences = current;
+        _selectedEdge = current.Edge;
+        _selectedMode = current.Mode;
+        _selectedSensitivity = current.Sensitivity;
+        _initialDrive = current.SelectedDrive;
+
         Title = "EdgePilot · Impostazioni";
-        Width = 480;
-        MinWidth = 420;
-        MinHeight = 400;
-        RequestedThemeVariant = OperatingSystem.IsLinux() ? Avalonia.Styling.ThemeVariant.Default : Avalonia.Styling.ThemeVariant.Dark;
-        Height = 650;
+        Icon = AppIcon.Load();
+        Width = 900;
+        Height = 640;
+        MinWidth = 760;
+        MinHeight = 560;
         CanResize = true;
         WindowStartupLocation = WindowStartupLocation.CenterScreen;
-        var edge = new ComboBox
-        {
-            ItemsSource = new[] { "Destra", "Sinistra", "Alto", "Basso" },
-            SelectedIndex = (int)current.Edge,
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-        var mode = new ComboBox
-        {
-            ItemsSource = new[] { "Al passaggio del mouse", "Sempre aperto", "Nascosto" },
-            SelectedIndex = (int)current.Mode,
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-        var intervals = new[] { 500, 1000, 2000, 5000 };
-        var refresh = new ComboBox
-        {
-            ItemsSource = new[] { "Ogni 0,5 secondi", "Ogni secondo", "Ogni 2 secondi", "Ogni 5 secondi" },
-            SelectedIndex = Array.IndexOf(intervals, current.RefreshIntervalMs),
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-        var sensitivity = new ComboBox
-        {
-            ItemsSource = new[] { "Precisa", "Normale", "Ampia" },
-            SelectedIndex = (int)current.Sensitivity,
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-        var metricOptions = new[] { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
-        var metricNames = new[] { "CPU", "Memoria", "Disco", "Rete" };
-        var metrics = metricOptions.Select((flag, index) => new CheckBox
-        {
-            Content = metricNames[index], IsChecked = current.Metrics.HasFlag(flag)
-        }).ToArray();
-        var metricPanel = new WrapPanel();
-        foreach (var metric in metrics)
-        {
-            metric.Margin = new Thickness(0, 0, 16, 0);
-            metricPanel.Children.Add(metric);
-        }
-        _initialDrive = current.SelectedDrive;
+        RequestedThemeVariant = OperatingSystem.IsLinux() ? ThemeVariant.Default : ThemeVariant.Dark;
+
         _drive = new ComboBox
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            MaxDropDownHeight = 280
+            MaxDropDownHeight = 280,
+            MinWidth = 260
         };
         UpdateDrives(drives ?? Array.Empty<DriveSnapshot>());
-        var autostart = new CheckBox { Content = "Avvia all’accesso", IsChecked = current.StartAtLogin };
-        var exitButton = new Button { Content = "Esci da EdgePilot" };
-        exitButton.Click += (_, _) => { if (exit is not null) exit(); else Close(); };
-        var message = new TextBlock
+
+        _refresh = new ComboBox
         {
-            Text = warning ?? "Premi Applica per salvare le modifiche.",
-            TextWrapping = Avalonia.Media.TextWrapping.Wrap
+            ItemsSource = new[] { "Ogni 0,5 secondi", "Ogni secondo", "Ogni 2 secondi", "Ogni 5 secondi" },
+            SelectedIndex = Array.IndexOf(_intervals, current.RefreshIntervalMs),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            MinWidth = 220
         };
-        var applyButton = new Button { Content = "Applica", HorizontalAlignment = HorizontalAlignment.Right };
-        applyButton.Click += (_, _) =>
+
+        var metricOptions = new[] { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
+        var metricNames = new[] { "CPU", "Memoria", "Disco", "Rete" };
+        _metrics = metricOptions.Select((flag, index) => new CheckBox
         {
-            VisibleMetrics selected = 0;
-            for (var i = 0; i < metrics.Length; i++)
-                if (metrics[i].IsChecked == true) selected |= metricOptions[i];
-            if (selected == 0)
-            {
-                message.Text = "Seleziona almeno una metrica da mostrare.";
-                return;
-            }
-            var value = new NotchPreferences((EdgeSide)edge.SelectedIndex, (NotchDisplayMode)mode.SelectedIndex)
-            {
-                RefreshIntervalMs = intervals[refresh.SelectedIndex],
-                Sensitivity = (HoverSensitivity)sensitivity.SelectedIndex,
-                Metrics = selected,
-                SelectedDrive = (_drive.SelectedItem as DriveChoice)?.Name,
-                StartAtLogin = autostart.IsChecked == true
-            };
-            try
-            {
-                if (savePreferences is not null) savePreferences(value);
-                else PreferenceStore.Save(storagePath ?? PreferenceStore.DefaultPath, value);
-                apply(value);
-                message.Text = value.Mode == NotchDisplayMode.Hidden
-                    ? (hasTray ? "Pannello nascosto. Usa l’icona nell’area di notifica per mostrarlo o riaprire le impostazioni."
-                        : "Pannello nascosto. Scegli un’altra modalità per mostrarlo. Chiudendo le impostazioni esci da EdgePilot; al prossimo avvio tornerai qui.")
-                    : "Impostazioni salvate. Fai clic destro sul pannello per riaprirle.";
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or System.Security.SecurityException)
-            {
-                System.Diagnostics.Trace.WriteLine(ex);
-                message.Text = "Impossibile salvare le impostazioni. Le preferenze attive non sono cambiate. Verifica i permessi di scrittura e lo spazio disponibile, poi riprova.";
-            }
+            Content = metricNames[index],
+            IsChecked = current.Metrics.HasFlag(flag),
+            FontWeight = FontWeight.SemiBold
+        }).ToArray();
+
+        _autostart = new CheckBox
+        {
+            Content = "Avvia EdgePilot all’accesso",
+            IsChecked = current.StartAtLogin,
+            FontWeight = FontWeight.SemiBold
         };
-        Content = new ScrollViewer { Content = new StackPanel
+
+        _previewNotch = new Border
         {
-            Margin = new Thickness(24),
-            Spacing = 12,
-            Children =
-            {
-                new TextBlock { Text = "Personalizza EdgePilot", FontSize = 22 },
-                new TextBlock { Text = "Bordo dello schermo" }, edge,
-                new TextBlock { Text = "Visualizzazione" }, mode,
-                new TextBlock { Text = "Metriche visibili" }, metricPanel,
-                new TextBlock { Text = "Aggiornamento dei dati" }, refresh,
-                new TextBlock { Text = "Sensibilità di apertura" }, sensitivity,
-                new TextBlock
-                {
-                    Text = "Ampia: il pannello si apre anche passando vicino alla linguetta. Precisa: occorre avvicinarsi di più al bordo.",
-                    TextWrapping = Avalonia.Media.TextWrapping.Wrap
-                },
-                new TextBlock { Text = "Disco da visualizzare" }, _drive,
-                new TextBlock
-                {
-                    Text = "Sono elencati i volumi montati e accessibili. Se manca un disco, montalo: l’elenco si aggiorna automaticamente.",
-                    TextWrapping = Avalonia.Media.TextWrapping.Wrap
-                },
-                autostart,
-                message, applyButton,
-                new StackPanel { Children = { exitButton } }
-            }
-        } };
+            Background = AccentBrush,
+            CornerRadius = new CornerRadius(6)
+        };
+        var previewGrid = new Grid();
+        previewGrid.Children.Add(new TextBlock
+        {
+            Text = "DESKTOP",
+            Foreground = MutedBrush,
+            FontSize = 11,
+            FontWeight = FontWeight.SemiBold,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center
+        });
+        previewGrid.Children.Add(_previewNotch);
+        _previewFrame = new Border
+        {
+            Width = 292,
+            Height = 178,
+            Background = PreviewBackgroundBrush,
+            BorderBrush = PreviewBorderBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(14),
+            Child = previewGrid
+        };
+
+        _edgeButtons =
+        [
+            SegmentButton("Destra", () => SelectEdge(EdgeSide.Right)),
+            SegmentButton("Sinistra", () => SelectEdge(EdgeSide.Left)),
+            SegmentButton("Alto", () => SelectEdge(EdgeSide.Top)),
+            SegmentButton("Basso", () => SelectEdge(EdgeSide.Bottom))
+        ];
+
+        _modeButtons =
+        [
+            SegmentButton("Hover", () => SelectMode(NotchDisplayMode.Hover)),
+            SegmentButton("Sempre aperto", () => SelectMode(NotchDisplayMode.Always)),
+            SegmentButton("Nascosto", () => SelectMode(NotchDisplayMode.Hidden))
+        ];
+
+        _sensitivityButtons =
+        [
+            SegmentButton("Precisa", () => SelectSensitivity(HoverSensitivity.Precise)),
+            SegmentButton("Normale", () => SelectSensitivity(HoverSensitivity.Normal)),
+            SegmentButton("Ampia", () => SelectSensitivity(HoverSensitivity.Wide))
+        ];
+
+        _status = new TextBlock
+        {
+            Text = warning ?? "Nessuna modifica da salvare.",
+            TextWrapping = TextWrapping.Wrap,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        _applyButton = new Button
+        {
+            Content = "Salva modifiche",
+            Background = AccentBrush,
+            Padding = new Thickness(18, 9),
+            MinWidth = 130,
+            IsEnabled = false
+        };
+        _resetButton = new Button
+        {
+            Content = "Annulla modifiche",
+            Padding = new Thickness(14, 9),
+            IsEnabled = false
+        };
+
+        _drive.SelectionChanged += (_, _) => MarkDirty();
+        _refresh.SelectionChanged += (_, _) => MarkDirty();
+        foreach (var metric in _metrics) metric.Click += (_, _) => MarkDirty();
+        _autostart.Click += (_, _) => MarkDirty();
+
+        _resetButton.Click += (_, _) => ResetToSaved();
+        _applyButton.Click += (_, _) => SaveChanges(apply, savePreferences, storagePath, hasTray);
+
+        _pageHost = new ContentControl
+        {
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Stretch
+        };
+
+        _pages[SettingsPage.Edge] = BuildEdgePage();
+        _pages[SettingsPage.Monitor] = BuildMonitorPage();
+        _pages[SettingsPage.Behavior] = BuildBehaviorPage();
+        _pages[SettingsPage.Startup] = BuildStartupPage(exit);
+        _pages[SettingsPage.About] = BuildAboutPage();
+
+        _header = BuildHeader();
+        _sidebar = BuildSidebar();
+        _footer = BuildFooter();
+
+        var shell = new Grid
+        {
+            RowDefinitions = new RowDefinitions("76,*,68")
+        };
+        shell.Children.Add(_header);
+        Grid.SetRow(_header, 0);
+
+        var body = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("190,*")
+        };
+        body.Children.Add(_sidebar);
+        Grid.SetColumn(_sidebar, 0);
+        body.Children.Add(_pageHost);
+        Grid.SetColumn(_pageHost, 1);
+        shell.Children.Add(body);
+        Grid.SetRow(body, 1);
+
+        shell.Children.Add(_footer);
+        Grid.SetRow(_footer, 2);
+        Content = shell;
+
+        _ready = true;
+        SelectEdge(current.Edge, markDirty: false);
+        SelectMode(current.Mode, markDirty: false);
+        SelectSensitivity(current.Sensitivity, markDirty: false);
+        ShowPage(SettingsPage.Edge);
+        ApplyTheme();
+        ActualThemeVariantChanged += (_, _) => ApplyTheme();
     }
+
     public void UpdateDrives(IReadOnlyList<DriveSnapshot> drives)
     {
-        var selected = _drive.SelectedItem is DriveChoice current ? current.Name : _initialDrive;
+        var selected = _drive?.SelectedItem is DriveChoice current ? current.Name : _initialDrive;
         var choices = DriveSelection.Choices(drives, selected);
-        if (_drive.ItemsSource is IReadOnlyList<DriveChoice> old && old.SequenceEqual(choices)) return;
+        if (_drive?.ItemsSource is IReadOnlyList<DriveChoice> old && old.SequenceEqual(choices)) return;
+        if (_drive is null) return;
         _drive.ItemsSource = choices;
         _drive.SelectedItem = choices.First(x => DriveSelection.PathComparer.Equals(x.Name, selected));
+    }
+
+    private Border BuildHeader()
+    {
+        var title = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                new Border
+                {
+                    Width = 7,
+                    Height = 32,
+                    Background = AccentBrush,
+                    CornerRadius = new CornerRadius(4)
+                },
+                new StackPanel
+                {
+                    Spacing = 1,
+                    Children =
+                    {
+                        new TextBlock { Text = "EdgePilot", FontSize = 20, FontWeight = FontWeight.SemiBold },
+                        new TextBlock { Text = "Impostazioni", FontSize = 12, Foreground = MutedBrush }
+                    }
+                }
+            }
+        };
+
+        var badge = new Border
+        {
+            Background = AccentSoftBrush,
+            BorderBrush = AccentBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(999),
+            Padding = new Thickness(10, 4),
+            VerticalAlignment = VerticalAlignment.Center,
+            Child = new TextBlock
+            {
+                Text = "PREVIEW 0.1",
+                FontSize = 10,
+                FontWeight = FontWeight.SemiBold
+            }
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            Margin = new Thickness(24, 0)
+        };
+        grid.Children.Add(title);
+        grid.Children.Add(badge);
+        Grid.SetColumn(badge, 1);
+
+        return new Border
+        {
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            Child = grid
+        };
+    }
+
+    private Border BuildSidebar()
+    {
+        var nav = new StackPanel
+        {
+            Spacing = 4,
+            Margin = new Thickness(14, 18)
+        };
+        nav.Children.Add(new TextBlock
+        {
+            Text = "SETTINGS",
+            FontSize = 10,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = MutedBrush,
+            Margin = new Thickness(10, 0, 0, 8)
+        });
+        nav.Children.Add(NavButton("Edge", SettingsPage.Edge));
+        nav.Children.Add(NavButton("Monitor", SettingsPage.Monitor));
+        nav.Children.Add(NavButton("Behavior", SettingsPage.Behavior));
+        nav.Children.Add(NavButton("Startup", SettingsPage.Startup));
+        nav.Children.Add(NavButton("About", SettingsPage.About));
+
+        return new Border
+        {
+            BorderThickness = new Thickness(0, 0, 1, 0),
+            Child = nav
+        };
+    }
+
+    private Border BuildFooter()
+    {
+        var statusDot = new Border
+        {
+            Width = 7,
+            Height = 7,
+            Background = AccentBrush,
+            CornerRadius = new CornerRadius(4),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 9, 0)
+        };
+        var statusRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { statusDot, _status }
+        };
+
+        var actions = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { _resetButton, _applyButton }
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            Margin = new Thickness(24, 0)
+        };
+        grid.Children.Add(statusRow);
+        grid.Children.Add(actions);
+        Grid.SetColumn(actions, 1);
+
+        return new Border
+        {
+            BorderThickness = new Thickness(0, 1, 0, 0),
+            Child = grid
+        };
+    }
+
+    private Control BuildEdgePage()
+    {
+        var positionOptions = new StackPanel
+        {
+            Spacing = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                Label("Posizione"),
+                Description("Scegli da quale bordo EdgePilot deve emergere."),
+                SegmentRow(_edgeButtons)
+            }
+        };
+
+        var previewLayout = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,*"),
+            ColumnSpacing = 24
+        };
+        previewLayout.Children.Add(_previewFrame);
+        previewLayout.Children.Add(positionOptions);
+        Grid.SetColumn(positionOptions, 1);
+
+        return Page(
+            "Edge",
+            "Decidi dove vive EdgePilot e come deve comparire sul desktop.",
+            Card(
+                SectionTitle("Bordo dello schermo"),
+                Description("La preview mostra la posizione reale della linguetta rispetto allo schermo."),
+                previewLayout),
+            Card(
+                SectionTitle("Visualizzazione"),
+                Description("Hover resta discreto, Sempre aperto mantiene il pannello visibile, Nascosto lo rimuove dal bordo."),
+                SegmentRow(_modeButtons)));
+    }
+
+    private Control BuildMonitorPage()
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,*"),
+            RowDefinitions = new RowDefinitions("Auto,Auto"),
+            ColumnSpacing = 12,
+            RowSpacing = 12
+        };
+
+        var descriptions = new[]
+        {
+            "Utilizzo del processore",
+            "Memoria in uso",
+            "Spazio del volume selezionato",
+            "Download e upload"
+        };
+        for (var i = 0; i < _metrics.Length; i++)
+        {
+            var tile = MetricTile(_metrics[i], descriptions[i]);
+            grid.Children.Add(tile);
+            Grid.SetColumn(tile, i % 2);
+            Grid.SetRow(tile, i / 2);
+        }
+
+        return Page(
+            "Monitor",
+            "Scegli quali informazioni del modulo System devono apparire nella notch.",
+            Card(
+                SectionTitle("Metriche visibili"),
+                Description("Mostra solo ciò che ti serve. EdgePilot adatta automaticamente l’altezza del pannello."),
+                grid),
+            Card(
+                SectionTitle("Disco"),
+                Description("Seleziona il volume usato dalla metrica Disco. I volumi montati vengono aggiornati automaticamente."),
+                _drive));
+    }
+
+    private Control BuildBehaviorPage()
+    {
+        return Page(
+            "Behavior",
+            "Regola frequenza dei dati e sensibilità dell’interazione con il bordo.",
+            Card(
+                SectionTitle("Aggiornamento dei dati"),
+                Description("Una frequenza più alta rende i valori più reattivi; una più bassa riduce il lavoro in background."),
+                _refresh),
+            Card(
+                SectionTitle("Sensibilità di apertura"),
+                Description("Precisa richiede di arrivare vicino alla linguetta. Ampia rende più facile intercettare EdgePilot passando vicino al bordo."),
+                SegmentRow(_sensitivityButtons)));
+    }
+
+    private Control BuildStartupPage(Action? exit)
+    {
+        var exitButton = new Button
+        {
+            Content = "Esci da EdgePilot",
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Padding = new Thickness(14, 8)
+        };
+        exitButton.Click += (_, _) =>
+        {
+            if (exit is not null) exit();
+            else Close();
+        };
+
+        return Page(
+            "Startup",
+            "Controlla come EdgePilot si avvia e rimane disponibile nella sessione desktop.",
+            Card(
+                SectionTitle("Avvio automatico"),
+                Description("Avvia EdgePilot per l’utente corrente quando accedi al sistema."),
+                _autostart),
+            Card(
+                SectionTitle("Sessione"),
+                Description("Chiude completamente EdgePilot e il processo in esecuzione."),
+                exitButton));
+    }
+
+    private Control BuildAboutPage()
+    {
+        return Page(
+            "About",
+            "Informazioni sul progetto e sui principi della preview corrente.",
+            Card(
+                new TextBlock
+                {
+                    Text = "EdgePilot",
+                    FontSize = 26,
+                    FontWeight = FontWeight.SemiBold
+                },
+                new TextBlock
+                {
+                    Text = "Your desktop has edges. EdgePilot makes them useful.",
+                    FontSize = 16,
+                    TextWrapping = TextWrapping.Wrap
+                },
+                Description("Early preview · Windows + Linux · Avalonia + .NET"),
+                Divider(),
+                new TextBlock
+                {
+                    Text = "Local first",
+                    FontWeight = FontWeight.SemiBold
+                },
+                Description("Nessun account, nessun backend cloud e nessun uploader di telemetria. Le metriche vengono lette sul computer locale.")));
+    }
+
+    private ScrollViewer Page(string title, string subtitle, params Control[] sections)
+    {
+        var stack = new StackPanel
+        {
+            Margin = new Thickness(30, 26, 30, 30),
+            Spacing = 16
+        };
+        stack.Children.Add(new TextBlock
+        {
+            Text = title,
+            FontSize = 28,
+            FontWeight = FontWeight.SemiBold
+        });
+        stack.Children.Add(new TextBlock
+        {
+            Text = subtitle,
+            Foreground = MutedBrush,
+            FontSize = 14,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, -8, 0, 8)
+        });
+        foreach (var section in sections) stack.Children.Add(section);
+        return new ScrollViewer { Content = stack };
+    }
+
+    private Border Card(params Control[] children)
+    {
+        var stack = new StackPanel { Spacing = 12 };
+        foreach (var child in children) stack.Children.Add(child);
+        var card = new Border
+        {
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(14),
+            Padding = new Thickness(18),
+            Child = stack
+        };
+        _cards.Add(card);
+        return card;
+    }
+
+    private Border MetricTile(CheckBox checkbox, string description)
+    {
+        var tile = new Border
+        {
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(11),
+            Padding = new Thickness(14),
+            Child = new StackPanel
+            {
+                Spacing = 6,
+                Children =
+                {
+                    checkbox,
+                    Description(description)
+                }
+            }
+        };
+        _tiles.Add(tile);
+        return tile;
+    }
+
+    private static TextBlock SectionTitle(string text) => new()
+    {
+        Text = text,
+        FontSize = 16,
+        FontWeight = FontWeight.SemiBold
+    };
+
+    private static TextBlock Label(string text) => new()
+    {
+        Text = text,
+        FontWeight = FontWeight.SemiBold
+    };
+
+    private static TextBlock Description(string text) => new()
+    {
+        Text = text,
+        Foreground = MutedBrush,
+        FontSize = 12,
+        TextWrapping = TextWrapping.Wrap
+    };
+
+    private static Border Divider() => new()
+    {
+        Height = 1,
+        Background = new SolidColorBrush(Color.FromArgb(60, 128, 128, 128)),
+        Margin = new Thickness(0, 4)
+    };
+
+    private static StackPanel SegmentRow(IEnumerable<Button> buttons)
+    {
+        var row = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8
+        };
+        foreach (var button in buttons) row.Children.Add(button);
+        return row;
+    }
+
+    private static Button SegmentButton(string text, Action select)
+    {
+        var button = new Button
+        {
+            Content = text,
+            Padding = new Thickness(13, 8),
+            MinWidth = 72
+        };
+        button.Click += (_, _) => select();
+        return button;
+    }
+
+    private Button NavButton(string text, SettingsPage page)
+    {
+        var button = new Button
+        {
+            Content = text,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+            Padding = new Thickness(12, 10),
+            BorderThickness = new Thickness(0)
+        };
+        button.Click += (_, _) => ShowPage(page);
+        _navButtons[page] = button;
+        return button;
+    }
+
+    private void ShowPage(SettingsPage page)
+    {
+        _selectedPage = page;
+        _pageHost.Content = _pages[page];
+        foreach (var item in _navButtons)
+        {
+            var selected = item.Key == page;
+            item.Value.Background = selected ? AccentSoftBrush : Brushes.Transparent;
+            item.Value.BorderBrush = selected ? AccentBrush : Brushes.Transparent;
+            item.Value.BorderThickness = selected ? new Thickness(3, 0, 0, 0) : new Thickness(0);
+        }
+    }
+
+    private void SelectEdge(EdgeSide edge, bool markDirty = true)
+    {
+        _selectedEdge = edge;
+        UpdateSegments(_edgeButtons, (int)edge);
+        UpdatePreview();
+        if (markDirty) MarkDirty();
+    }
+
+    private void SelectMode(NotchDisplayMode mode, bool markDirty = true)
+    {
+        _selectedMode = mode;
+        UpdateSegments(_modeButtons, (int)mode);
+        if (markDirty) MarkDirty();
+    }
+
+    private void SelectSensitivity(HoverSensitivity sensitivity, bool markDirty = true)
+    {
+        _selectedSensitivity = sensitivity;
+        UpdateSegments(_sensitivityButtons, (int)sensitivity);
+        if (markDirty) MarkDirty();
+    }
+
+    private static void UpdateSegments(IReadOnlyList<Button> buttons, int selectedIndex)
+    {
+        for (var i = 0; i < buttons.Count; i++)
+        {
+            var selected = i == selectedIndex;
+            buttons[i].Background = selected ? AccentBrush : Brushes.Transparent;
+            buttons[i].BorderBrush = selected ? AccentBrush : new SolidColorBrush(Color.FromArgb(70, 128, 128, 128));
+            buttons[i].BorderThickness = new Thickness(1);
+        }
+    }
+
+    private void UpdatePreview()
+    {
+        _previewNotch.HorizontalAlignment = _selectedEdge switch
+        {
+            EdgeSide.Left => HorizontalAlignment.Left,
+            EdgeSide.Right => HorizontalAlignment.Right,
+            _ => HorizontalAlignment.Center
+        };
+        _previewNotch.VerticalAlignment = _selectedEdge switch
+        {
+            EdgeSide.Top => VerticalAlignment.Top,
+            EdgeSide.Bottom => VerticalAlignment.Bottom,
+            _ => VerticalAlignment.Center
+        };
+        var horizontal = _selectedEdge is EdgeSide.Top or EdgeSide.Bottom;
+        _previewNotch.Width = horizontal ? 64 : 12;
+        _previewNotch.Height = horizontal ? 12 : 64;
+        _previewNotch.CornerRadius = new CornerRadius(6);
+    }
+
+    private VisibleMetrics SelectedMetrics()
+    {
+        var options = new[] { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
+        VisibleMetrics selected = 0;
+        for (var i = 0; i < _metrics.Length; i++)
+            if (_metrics[i].IsChecked == true) selected |= options[i];
+        return selected;
+    }
+
+    private NotchPreferences CurrentPreferences()
+    {
+        return new NotchPreferences(_selectedEdge, _selectedMode)
+        {
+            RefreshIntervalMs = _intervals[_refresh.SelectedIndex],
+            Sensitivity = _selectedSensitivity,
+            Metrics = SelectedMetrics(),
+            SelectedDrive = (_drive.SelectedItem as DriveChoice)?.Name,
+            StartAtLogin = _autostart.IsChecked == true
+        };
+    }
+
+    private void MarkDirty()
+    {
+        if (!_ready) return;
+        var current = CurrentPreferences();
+        var dirty = current != _savedPreferences;
+        _applyButton.IsEnabled = dirty;
+        _resetButton.IsEnabled = dirty;
+        if (dirty) _status.Text = "Modifiche non salvate.";
+        else _status.Text = "Nessuna modifica da salvare.";
+    }
+
+    private void ResetToSaved()
+    {
+        _ready = false;
+        _selectedEdge = _savedPreferences.Edge;
+        _selectedMode = _savedPreferences.Mode;
+        _selectedSensitivity = _savedPreferences.Sensitivity;
+        _refresh.SelectedIndex = Array.IndexOf(_intervals, _savedPreferences.RefreshIntervalMs);
+        var options = new[] { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
+        for (var i = 0; i < _metrics.Length; i++) _metrics[i].IsChecked = _savedPreferences.Metrics.HasFlag(options[i]);
+        _autostart.IsChecked = _savedPreferences.StartAtLogin;
+        if (_drive.ItemsSource is IReadOnlyList<DriveChoice> choices)
+            _drive.SelectedItem = choices.First(x => DriveSelection.PathComparer.Equals(x.Name, _savedPreferences.SelectedDrive));
+        UpdateSegments(_edgeButtons, (int)_selectedEdge);
+        UpdateSegments(_modeButtons, (int)_selectedMode);
+        UpdateSegments(_sensitivityButtons, (int)_selectedSensitivity);
+        UpdatePreview();
+        _ready = true;
+        _applyButton.IsEnabled = false;
+        _resetButton.IsEnabled = false;
+        _status.Text = "Modifiche annullate.";
+    }
+
+    private void SaveChanges(Action<NotchPreferences> apply, Action<NotchPreferences>? savePreferences, string? storagePath, bool hasTray)
+    {
+        var selectedMetrics = SelectedMetrics();
+        if (selectedMetrics == 0)
+        {
+            _status.Text = "Seleziona almeno una metrica da mostrare.";
+            ShowPage(SettingsPage.Monitor);
+            return;
+        }
+
+        var value = CurrentPreferences();
+        try
+        {
+            if (savePreferences is not null) savePreferences(value);
+            else PreferenceStore.Save(storagePath ?? PreferenceStore.DefaultPath, value);
+            apply(value);
+            _savedPreferences = value;
+            _applyButton.IsEnabled = false;
+            _resetButton.IsEnabled = false;
+            _status.Text = value.Mode == NotchDisplayMode.Hidden
+                ? (hasTray
+                    ? "Pannello nascosto. Puoi riaprirlo dall’area di notifica."
+                    : "Pannello nascosto. Chiudendo le impostazioni esci da EdgePilot; al prossimo avvio tornerai qui.")
+                : "Impostazioni salvate.";
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or System.Security.SecurityException)
+        {
+            System.Diagnostics.Trace.WriteLine(ex);
+            _status.Text = "Impossibile salvare le impostazioni. Verifica permessi e spazio disponibile, poi riprova.";
+            _applyButton.IsEnabled = true;
+        }
+    }
+
+    private void ApplyTheme()
+    {
+        var dark = ActualThemeVariant == ThemeVariant.Dark;
+        Background = Brush(dark ? "#121212" : "#F4F4F5");
+        _header.Background = Brush(dark ? "#151515" : "#FFFFFF");
+        _sidebar.Background = Brush(dark ? "#141414" : "#FAFAFA");
+        _footer.Background = Brush(dark ? "#151515" : "#FFFFFF");
+
+        var line = Brush(dark ? "#2C2C2C" : "#DDDDDF");
+        _header.BorderBrush = line;
+        _sidebar.BorderBrush = line;
+        _footer.BorderBrush = line;
+
+        foreach (var card in _cards)
+        {
+            card.Background = Brush(dark ? "#191919" : "#FFFFFF");
+            card.BorderBrush = Brush(dark ? "#2D2D2D" : "#E2E2E4");
+        }
+        foreach (var tile in _tiles)
+        {
+            tile.Background = Brush(dark ? "#1F1F1F" : "#F8F8F9");
+            tile.BorderBrush = Brush(dark ? "#343434" : "#E6E6E8");
+        }
+        ShowPage(_selectedPage);
+    }
+
+    private static IBrush Brush(string color) => new SolidColorBrush(Color.Parse(color));
+
+    private enum SettingsPage
+    {
+        Edge,
+        Monitor,
+        Behavior,
+        Startup,
+        About
     }
 }

--- a/tests/EdgePilot.LocalizationChecks/EdgePilot.LocalizationChecks.csproj
+++ b/tests/EdgePilot.LocalizationChecks/EdgePilot.LocalizationChecks.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/EdgePilot/EdgePilot.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/EdgePilot.LocalizationChecks/Program.cs
+++ b/tests/EdgePilot.LocalizationChecks/Program.cs
@@ -1,0 +1,56 @@
+using EdgePilot.Core;
+using EdgePilot.UI;
+
+var passed = 0;
+void Check(bool condition, string name)
+{
+    if (!condition) throw new Exception(name);
+    Console.WriteLine("PASS " + name);
+    passed++;
+}
+
+Localization.SetLanguage(Language.Italian);
+Check(Localization.T("nav.about") == "Informazioni", "Italian navigation translation");
+Check(Localization.T("settings.saveChanges") == "Salva modifiche", "Italian settings translation");
+Check(Localization.T("tray.exit") == "Esci", "Italian tray translation");
+
+Localization.SetLanguage(Language.English);
+Check(Localization.T("nav.about") == "About", "English navigation translation");
+Check(Localization.T("settings.saveChanges") == "Save changes", "English settings translation");
+Check(Localization.T("tray.exit") == "Exit", "English tray translation");
+
+Localization.SetLanguage(Language.French);
+Check(Localization.T("nav.about") == "À propos", "French navigation translation");
+Check(Localization.T("settings.saveChanges") == "Enregistrer", "French settings translation");
+Check(Localization.T("tray.exit") == "Quitter", "French tray translation");
+Check(Localization.T("tooltip.processors", 8).Contains("8"), "formatted translations preserve arguments");
+Check(Localization.T("missing.translation.key") == "missing.translation.key", "unknown key has safe fallback");
+
+var directory = Path.Combine(Path.GetTempPath(), "edgepilot-i18n-checks-" + Guid.NewGuid().ToString("N"));
+var path = Path.Combine(directory, "settings.json");
+try
+{
+    var french = new NotchPreferences { Language = Language.French };
+    PreferenceStore.Save(path, french);
+    Check(PreferenceStore.Load(path).Language == Language.French, "explicit language persists");
+
+    var automatic = french with { Language = null };
+    PreferenceStore.Save(path, automatic);
+    Check(PreferenceStore.Load(path).Language is null, "automatic language persists");
+
+    try
+    {
+        PreferenceStore.Save(path, new NotchPreferences { Language = (Language)999 });
+        Check(false, "invalid language rejected");
+    }
+    catch (InvalidDataException)
+    {
+        Check(PreferenceStore.Load(path).Language is null, "invalid language does not replace last good settings");
+    }
+}
+finally
+{
+    if (Directory.Exists(directory)) Directory.Delete(directory, true);
+}
+
+Console.WriteLine($"{passed} localization checks passed.");

--- a/tests/EdgePilot.UxChecks/LocalizationTestBootstrap.cs
+++ b/tests/EdgePilot.UxChecks/LocalizationTestBootstrap.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+using EdgePilot.Core;
+
+internal static class LocalizationTestBootstrap
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        Localization.SystemLanguageDetectorOverride = () => Language.Italian;
+        Localization.SetLanguage(Language.Italian);
+    }
+}

--- a/tests/EdgePilot.UxChecks/Program.cs
+++ b/tests/EdgePilot.UxChecks/Program.cs
@@ -20,6 +20,9 @@ object? Field(EdgeWindow w, string name) => typeof(EdgeWindow).GetField(name, fl
 object? Call(EdgeWindow w, string name, params object[] args) =>
     typeof(EdgeWindow).GetMethod(name, flags)!.Invoke(w, args);
 void Set(EdgeWindow w, string name, object value) => typeof(EdgeWindow).GetField(name, flags)!.SetValue(w, value);
+object? SettingsField(SettingsWindow w, string name) => typeof(SettingsWindow).GetField(name, flags)!.GetValue(w);
+object? SettingsCall(SettingsWindow w, string name, params object[] args) =>
+    typeof(SettingsWindow).GetMethod(name, flags)!.Invoke(w, args);
 
 foreach (var frame in new[] { 1d / 30, 1d / 60, 1d / 144, 0.5 })
 {
@@ -249,27 +252,38 @@ try
     File.WriteAllText(settingsPath, "{\"Edge\":999,\"Mode\":0}");
     try { PreferenceStore.Load(settingsPath); Check(false, "unknown enum rejected"); }
     catch (InvalidDataException) { Check(true, "unknown enum reported"); }
+
     NotchPreferences? applied = null;
     var settings = new SettingsWindow(new NotchPreferences(), value => applied = value,
         storagePath: settingsPath);
-    var settingsPanel = (StackPanel)((ScrollViewer)settings.Content!).Content!;
-    var selectors = settingsPanel.Children.OfType<ComboBox>().ToArray();
-    selectors[0].SelectedIndex = (int)EdgeSide.Bottom;
-    selectors[1].SelectedIndex = (int)NotchDisplayMode.Always;
-    settingsPanel.Children.OfType<Button>().Single(x => Equals(x.Content, "Applica")).RaiseEvent(
-        new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+    Check(settings.Content is Grid, "settings uses structured shell");
+    var applyButton = (Button)SettingsField(settings, "_applyButton")!;
+    var resetButton = (Button)SettingsField(settings, "_resetButton")!;
+    var refreshSelector = (ComboBox)SettingsField(settings, "_refresh")!;
+    var metricChecks = (CheckBox[])SettingsField(settings, "_metrics")!;
+    var previewNotch = (Border)SettingsField(settings, "_previewNotch")!;
+
+    SettingsCall(settings, "SelectEdge", EdgeSide.Bottom, true);
+    SettingsCall(settings, "SelectMode", NotchDisplayMode.Always, true);
+    Check(previewNotch.VerticalAlignment == Avalonia.Layout.VerticalAlignment.Bottom,
+        "settings preview follows selected edge");
+    Check(applyButton.IsEnabled && resetButton.IsEnabled, "settings dirty state enables actions");
+    applyButton.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
     Check(applied == new NotchPreferences(EdgeSide.Bottom, NotchDisplayMode.Always),
         "settings Apply invokes live update");
     Check(PreferenceStore.Load(settingsPath) == applied, "settings Apply persists chosen values");
-    selectors[2].SelectedIndex = 3;
-    selectors[3].SelectedIndex = (int)HoverSensitivity.Wide;
-    var checks = settingsPanel.Children.OfType<WrapPanel>().Single().Children.OfType<CheckBox>().ToArray();
-    foreach (var checkbox in checks) checkbox.IsChecked = false;
+    Check(!applyButton.IsEnabled && !resetButton.IsEnabled, "successful save clears dirty state");
+
+    refreshSelector.SelectedIndex = 3;
+    SettingsCall(settings, "SelectSensitivity", HoverSensitivity.Wide, true);
+    foreach (var checkbox in metricChecks) checkbox.IsChecked = false;
     applied = null;
-    settingsPanel.Children.OfType<Button>().Single(x => Equals(x.Content, "Applica")).RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+    applyButton.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
     Check(applied is null, "empty metric selection is not applied");
-    checks[3].IsChecked = true;
-    settingsPanel.Children.OfType<Button>().Single(x => Equals(x.Content, "Applica")).RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+    Check(((TextBlock)SettingsField(settings, "_status")!).Text?.StartsWith("Seleziona almeno una metrica") == true,
+        "empty metric selection is visible");
+    metricChecks[3].IsChecked = true;
+    applyButton.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
     Check(applied?.Metrics == VisibleMetrics.Network && applied.RefreshIntervalMs == 5000 &&
         applied.Sensitivity == HoverSensitivity.Wide, "new UI selections apply");
     Check(PreferenceStore.Load(settingsPath) == applied, "new UI selections persist");
@@ -278,19 +292,20 @@ try
     applied = null;
     var failingSettings = new SettingsWindow(new NotchPreferences(), value => applied = value,
         storagePath: temporaryDirectory);
-    var failingPanel = (StackPanel)((ScrollViewer)failingSettings.Content!).Content!;
-    failingPanel.Children.OfType<Button>().Single(x => Equals(x.Content, "Applica")).RaiseEvent(
+    SettingsCall(failingSettings, "SelectEdge", EdgeSide.Left, true);
+    ((Button)SettingsField(failingSettings, "_applyButton")!).RaiseEvent(
         new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
     Check(applied is null, "save failure does not apply changes");
-    Check(failingPanel.Children.OfType<TextBlock>().Any(x => x.Text?.StartsWith("Impossibile salvare") == true),
+    Check(((TextBlock)SettingsField(failingSettings, "_status")!).Text?.StartsWith("Impossibile salvare") == true,
         "save failure is visible");
     failingSettings.Close();
+
     var diskSettings = new SettingsWindow(new NotchPreferences { SelectedDrive = "/mnt/dati16" },
         value => applied = value, storagePath: settingsPath, drives: drives);
-    var diskPanel = (StackPanel)((ScrollViewer)diskSettings.Content!).Content!;
-    var diskSelector = diskPanel.Children.OfType<ComboBox>().Last();
+    var diskSelector = (ComboBox)SettingsField(diskSettings, "_drive")!;
     Check(((DriveChoice)diskSelector.SelectedItem!).Name == "/mnt/dati16", "saved disk selected in settings");
-    diskPanel.Children.OfType<Button>().Single(x => Equals(x.Content, "Applica")).RaiseEvent(
+    SettingsCall(diskSettings, "SelectMode", NotchDisplayMode.Always, true);
+    ((Button)SettingsField(diskSettings, "_applyButton")!).RaiseEvent(
         new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
     Check(applied?.SelectedDrive == "/mnt/dati16" && PreferenceStore.Load(settingsPath).SelectedDrive == "/mnt/dati16",
         "disk picker selection persists");
@@ -302,8 +317,7 @@ try
     {
         var caseSettings = new SettingsWindow(new NotchPreferences { SelectedDrive = @"c:\" },
             _ => { }, drives: new[] { new DriveSnapshot(@"C:\", "Sistema", 1000, 500) });
-        var casePanel = (StackPanel)((ScrollViewer)caseSettings.Content!).Content!;
-        Check(((DriveChoice)casePanel.Children.OfType<ComboBox>().Last().SelectedItem!).Name == @"C:\",
+        Check(((DriveChoice)((ComboBox)SettingsField(caseSettings, "_drive")!).SelectedItem!).Name == @"C:\",
             "Windows drive selection ignores casing");
         caseSettings.Close();
     }


### PR DESCRIPTION
## Goal
Turn Settings from a functional preview panel into a coherent EdgePilot product surface, while preserving every existing preference and behavior.

## v0.2 preview scope
- responsive settings shell with fixed header/footer and adaptive content layout
- settings split into shell, pages and reusable components for future modules
- canonical EdgePilot SVG rendered directly in the header and About page
- improved edge preview and clearer position/display controls
- interactive metric cards with visual selected state
- conditional disk settings: the volume selector is hidden when Disk is disabled
- improved labels, descriptions, grouping and icons across every settings page
- polished About page with product positioning, local-first principles, explicit author attribution to @pricootz, GitHub repository/profile links and the GitHub mark
- persistent save/reset state and existing validation/persistence behavior retained
- version bumped to 0.2.0-preview.1
- Windows dark theme plus Linux system light/dark adaptation
- IT / EN / FR localization with automatic system-language detection and a manual selector
- localized tray, tooltips, installer/autostart messages, drive labels and metric captions
- dedicated localization regression checks on Windows and Ubuntu CI

## Community contribution
The localization work was originally contributed by @IamArayel in PR #5 and has been integrated into the redesigned v0.2 architecture. Contributor credit is preserved in the resulting history/release notes.

## Verification
The complete v0.2 branch passes repository checks, application build, UX regression checks, localization checks, publish/package checks and install smoke tests on both Windows and Ubuntu.