### PR TITLE
docs: sync v0.2 main documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The v0.2 preview turns the initial system-monitor settings panel into a more coh
 - Responsive Settings shell with dedicated General, Edge, Monitor, Behavior, Startup and About sections.
 - General page for interface language and Settings appearance (`System`, `Light`, `Dark`).
 - Interactive metric cards with contextual configuration; the disk-volume selector is hidden when Disk is disabled.
-- Italian, English and French interface localization with automatic system-language detection and a persisted manual override.
+- Italian, English, French and Spanish interface localization with automatic system-language detection and a persisted manual override.
 - File-based locale assets under `Assets/Locales`, discovered automatically at build time so a new language is contributed as one JSON file rather than a C# catalog edit.
 - Safe language fallback: exact locale, neutral locale, English, then the key itself.
 - Backward-compatible migration of the original v0.2 `Italian` / `English` / `French` preference values to `it` / `en` / `fr`.
@@ -32,6 +32,7 @@ The v0.2 preview turns the initial system-monitor settings panel into a more coh
 
 - IT / EN / FR localization foundation contributed by [@IamArayel](https://github.com/IamArayel) in [PR #5](https://github.com/pricootz/edgepilot/pull/5), then reconciled with the v0.2 Settings redesign.
 - File-based locale architecture, translator-friendly workflow, fallback strategy, Linux locale metadata and translation validation ideas contributed by [@ArnieGA](https://github.com/ArnieGA) in [PR #8](https://github.com/pricootz/edgepilot/pull/8), reconciled without dropping the French localization or the current Settings architecture.
+- Spanish localization contributed by [@ArnieGA](https://github.com/ArnieGA) in [PR #12](https://github.com/pricootz/edgepilot/pull/12), using the file-per-language workflow against current `main`.
 
 ## 0.1.0-preview.1
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **v0.2 preview.** EdgePilot lives at the edge of the desktop and stays out of the way until it is useful. The current System module surfaces live local machine activity; the project is evolving toward contextual signals and actions that appear only when they matter.
 
-No account, server or telemetry uploader is required. The interface ships in **Italian, English and French**, follows the system language automatically, and can be extended with additional locale files.
+No account, server or telemetry uploader is required. The interface ships in **Italian, English, French and Spanish**, follows the system language automatically, and can be extended with additional locale files.
 
 <p align="center">
   <img src="docs/assets/windows11-notch.png" width="150" alt="Expanded EdgePilot notch showing system metrics on Windows 11">
@@ -23,7 +23,7 @@ No account, server or telemetry uploader is required. The interface ships in **I
 - Redesigned responsive Settings experience with dedicated **General, Edge, Monitor, Behavior, Startup and About** sections.
 - General page for interface language and Settings appearance (`System`, `Light`, `Dark`).
 - Interactive metric cards and contextual options: disabling Disk also hides its volume selector.
-- IT / EN / FR localization across Settings, tray, tooltips, installer messages and persisted preferences.
+- IT / EN / FR / ES localization across Settings, tray, tooltips, installer messages and persisted preferences.
 - Translator-friendly locale architecture under `Assets/Locales`: new languages are contributed as JSON files instead of C# catalog edits.
 - Safe locale fallback and backward-compatible migration from the first v0.2 language preferences.
 - Direct rendering of the canonical EdgePilot SVG in the app; Windows keeps a generated native ICO.
@@ -39,6 +39,7 @@ No account, server or telemetry uploader is required. The interface ships in **I
 - Placement on any of the four screen edges, with upright metric labels.
 - Persistent display modes, visible metrics, refresh interval, hover sensitivity, language, Settings appearance and disk selection.
 - Responsive Settings UI; Settings can follow the system theme or use an explicit light/dark choice.
+- Automatic language detection plus manual selection from the shipped IT / EN / FR / ES locale files.
 - Tray menu, optional start at login, per-user installation and single-instance activation.
 - Windows and Ubuntu CI builds, UX checks, localization checks, packaged launch and installation checks.
 - Local-first operation: no account, required cloud backend or telemetry uploader.
@@ -54,6 +55,8 @@ The first planned signals are intentionally small and reliable:
 - Sustained unusual CPU activity.
 
 The design goal is simple: **you should not have to open EdgePilot to discover that something important happened.**
+
+Signals are currently being developed separately and are not part of the v0.2 `main` behavior yet.
 
 ## Download and install
 
@@ -103,7 +106,7 @@ EdgePilot is created and primarily maintained by [@pricootz](https://github.com/
 
 The IT / EN / FR localization foundation was contributed by [@IamArayel](https://github.com/IamArayel) through [PR #5](https://github.com/pricootz/edgepilot/pull/5) and reconciled with the v0.2 Settings architecture.
 
-The file-based locale architecture, translator workflow, fallback strategy and localization validation ideas were contributed by [@ArnieGA](https://github.com/ArnieGA) through [PR #8](https://github.com/pricootz/edgepilot/pull/8) and reconciled without dropping the French localization or the current Settings design.
+The file-based locale architecture, translator workflow, fallback strategy and localization validation ideas were contributed by [@ArnieGA](https://github.com/ArnieGA) through [PR #8](https://github.com/pricootz/edgepilot/pull/8) and reconciled without dropping the French localization or the current Settings design. [@ArnieGA](https://github.com/ArnieGA) then contributed the shipped Spanish locale through [PR #12](https://github.com/pricootz/edgepilot/pull/12), validating the one-file-per-language workflow against current `main`.
 
 - [Settings](docs/SETTINGS.md) · [Desktop integration](docs/DESKTOP-INTEGRATION.md) · [Translating](docs/TRANSLATING.md)
 - [Architecture](docs/ARCHITECTURE.md) · [Product scope](docs/PRODUCT.md) · [Roadmap](docs/ROADMAP.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,19 +4,38 @@ EdgePilot uses C#/.NET 10 and Avalonia. The UI and platform sampling are separat
 
 ## Core
 
-SystemSnapshot holds immutable sampled data. ISystemMetricsProvider describes capture; SystemMonitorService centralizes refresh and error delivery.
+`SystemSnapshot` holds immutable sampled data. `ISystemMetricsProvider` describes capture; `SystemMonitorService` centralizes refresh and error delivery.
+
+Localization is also core application state. `Language` is an extensible locale-code value object rather than a closed enum, and `Localization` discovers embedded JSON catalogs from `src/EdgePilot/Assets/Locales`. Resolution follows exact locale -> neutral locale -> English -> key, while selected culture controls formatting.
 
 ## Platform
 
-SystemMetricsProvider combines CPU, memory, drive and network readers. Windows CPU/RAM use Win32 APIs; Linux uses /proc. DriveInfo and network APIs provide volume capacity and throughput sampling.
+`SystemMetricsProvider` combines CPU, memory, drive and network readers. Windows CPU/RAM use Win32 APIs; Linux uses `/proc`. `DriveInfo` and network APIs provide volume capacity and throughput sampling.
 
-AutostartRegistration manages current-user startup entries. DesktopInstaller copies packages into a stable per-user directory and creates a launcher. SingleInstance owns the per-user mutex and activation pipe.
+`AutostartRegistration` manages current-user startup entries. `DesktopInstaller` copies packages into a stable per-user directory and creates a launcher. `SingleInstance` owns the per-user mutex and activation pipe.
+
+Linux desktop-entry comments are generated for every shipped locale so desktop metadata remains consistent with the application language set.
 
 ## UI
 
-EdgeWindow owns interaction state and rendering. EdgeNotchGeometry supplies the shared silhouette and clip; NotchLayout maps geometry and hit targets to all four edges while preserving upright text. NotchSpring retains motion continuity when a transition reverses. MetricRing and DisplayFormat present snapshots.
+`EdgeWindow` owns interaction state and rendering. `EdgeNotchGeometry` supplies the shared silhouette and clip; `NotchLayout` maps geometry and hit targets to all four edges while preserving upright text. `NotchSpring` retains motion continuity when a transition reverses. `MetricRing` and `DisplayFormat` present snapshots.
 
-SettingsWindow edits NotchPreferences, saved atomically by PreferenceStore. DriveSelection resolves the explicit mount path without a silent substitute.
+`SettingsWindow` owns Settings state and navigation. Page composition lives under `UI/Settings`, keeping General, Edge, Monitor, Behavior, Startup and About separate from reusable controls.
+
+`NotchPreferences` stores persisted interface state including edge, display mode, visible metrics, refresh, hover sensitivity, selected disk, language and Settings theme. `PreferenceStore` saves atomically and preserves compatibility with the original v0.2 language values.
+
+Language choices are populated from the embedded locale catalogs, so shipping a new translation normally means adding one JSON file rather than changing Settings or introducing a new language enum.
+
+## Current localization assets
+
+Current `main` ships:
+
+- `en.json` — English
+- `it.json` — Italiano
+- `fr.json` — Français
+- `es.json` — Español
+
+`en.json` is the canonical key set. Repository validation requires every shipped locale to match it key-for-key and checks that source localization keys exist.
 
 ## Boundaries
 
@@ -24,10 +43,14 @@ SettingsWindow edits NotchPreferences, saved atomically by PreferenceStore. Driv
 - Platform details remain outside Core.
 - Placement uses the OS working area.
 - Failure should leave settings and recovery accessible.
+- Localization catalogs contain text; application behavior remains in code.
+- New languages should not require a closed language enum or Settings rewrite.
 - Extend a module contract only when another real module establishes its requirements.
 
 ## Verification
 
-The executable headless suite covers geometry, motion, interaction, settings and disk selection. CI adds native packaged launch, second-instance activation and per-user installation on disposable runners. Compositor behavior and actual login sessions require hands-on testing.
+The executable headless suites cover geometry, motion, interaction, settings, disk selection and localization behavior. CI adds repository/privacy validation, native packaged launch, second-instance activation and per-user installation on disposable Windows and Ubuntu runners. Compositor behavior and actual login sessions require hands-on testing.
+
+The next architecture direction is Signals / ambient awareness, but Signals are not part of current `main` behavior yet and are being developed separately until validated.
 
 The edge-attached interaction was informed by prior notch-style UI exploration. EdgePilot is maintained as its own codebase.

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,12 +1,16 @@
 # Product scope
 
-EdgePilot keeps useful local machine state one screen edge away. Its first preview focuses on a compact desktop monitor that opens when needed.
+EdgePilot is an edge-native desktop surface for Windows and Linux. The current `main` preview starts with local system monitoring, but the product direction is broader: surface useful state and actions from the screen edge only when they matter.
 
-## Included in v0.1
+## Included today
 
 Windows and Linux desktop support; CPU, physical memory, disk capacity, network throughput and interface details; uptime and machine identity; four-edge placement; hover expansion, delayed fold, pinning and tooltips; persistent settings; disk selection; tray integration; optional start at login; per-user installation.
 
-Refresh intervals are 0.5, 1, 2 or 5 seconds. Settings use Italian labels. Repository documentation uses English.
+The v0.2 product surface also includes a responsive Settings experience with General, Edge, Monitor, Behavior, Startup and About sections, automatic/manual language selection, and System/Light/Dark Settings appearance.
+
+Current `main` ships **English, Italian, French and Spanish** through embedded JSON locale catalogs. New languages are designed to be added as one locale file without changing Settings architecture or a closed C# language enum.
+
+Refresh intervals are 0.5, 1, 2 or 5 seconds. Repository documentation uses English.
 
 ## Interaction contract
 
@@ -16,7 +20,18 @@ Refresh intervals are 0.5, 1, 2 or 5 seconds. Settings use Italian labels. Repos
 4. Always-open and hidden modes are available independently of pointer interaction.
 5. Reopening the executable recovers settings through the running instance.
 6. Missing readings and missing selected volumes degrade visibly without inventing replacement data.
+7. Language and Settings appearance are persisted independently from the notch's dedicated visual style.
 
-## Future scope
+## Product direction
 
-Network interface selection, richer metrics, accessibility and broader desktop validation come before additional modules. Remote servers, Docker, clipboard tools and quick actions are ideas, not shipped features. GPU, temperature and fan sensors are not part of this preview.
+The next major direction is **Signals / ambient awareness** following the model:
+
+**Observe → Decide → Surface → Act**
+
+Signals are intended to be temporary, deduplicated and context-aware rather than another notification center. The first planned cases are Internet lost/restored, low disk space and sustained unusual CPU activity.
+
+Signals are being developed separately and are not part of the current `main` product behavior yet.
+
+## Not current scope
+
+Remote servers, Docker, clipboard tools, VPN/Tailscale, removable-device workflows and quick actions are future ideas, not shipped features. GPU, temperature and fan sensors are not part of this preview. macOS and ARM packages are not current supported targets.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,8 +21,9 @@ This roadmap is directional, not a delivery schedule.
 - [x] Interactive metric cards and conditional disk configuration.
 - [x] Canonical SVG branding inside the app and native Windows icon generation.
 - [x] Product-focused About page with author and GitHub links.
-- [x] Italian, English and French application localization.
+- [x] Italian, English, French and Spanish application localization.
 - [x] Automatic system-language detection plus persisted manual language selection.
+- [x] File-based locale discovery with one JSON file per shipped language.
 - [x] Localized tray, tooltip, installer and system-monitor strings.
 - [x] Split Settings implementation into shell, pages and reusable controls.
 - [x] Localization regression checks alongside existing UX/package CI.
@@ -33,7 +34,7 @@ This roadmap is directional, not a delivery schedule.
 - [ ] Verify real logout/login startup and tray behavior.
 - [ ] Test Settings at common scaling levels (100%, 125%, 150%) and smaller window sizes.
 - [ ] Validate all four edges and monitor changes on physical multi-monitor systems.
-- [ ] Confirm language switching and Automatic mode on Italian, English and French desktop locales.
+- [ ] Confirm language switching and Automatic mode on Italian, English, French and Spanish desktop locales.
 - [ ] Add current v0.2 Windows and Ubuntu screenshots.
 - [ ] Gather feedback from the preview release.
 
@@ -53,6 +54,8 @@ Architecture direction:
 - A signal service handles priority, deduplication, coalescing, rate limiting and expiry.
 - The edge temporarily morphs from its normal content into the active signal, then returns automatically.
 - Later signals may expose actions.
+
+Signals are being developed outside `main` until real-desktop behavior and CI are considered ready.
 
 ## Later exploration
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,6 +1,6 @@
 # Settings
 
-Open Settings by right-clicking the notch, choosing **Settings / Impostazioni / Paramètres** from the tray menu, or launching EdgePilot with `--settings`. Starting EdgePilot a second time activates the Settings window of the running instance.
+Open Settings by right-clicking the notch, choosing **Settings / Impostazioni / Paramètres / Ajustes** from the tray menu, or launching EdgePilot with `--settings`. Starting EdgePilot a second time activates the Settings window of the running instance.
 
 The v0.2 Settings experience is split into six sections.
 
@@ -8,7 +8,7 @@ The v0.2 Settings experience is split into six sections.
 
 App-level preferences live here.
 
-- **Interface language:** Automatic (system), plus every locale shipped under `src/EdgePilot/Assets/Locales`.
+- **Interface language:** Automatic (system), plus every locale shipped under `src/EdgePilot/Assets/Locales`. Current `main` includes English, Italian, French and Spanish.
 - **Settings appearance:** System, Light or Dark.
 
 Automatic language mode follows the operating-system UI culture. EdgePilot first looks for an exact shipped language tag, then a neutral language tag, then English. If a previously saved language is no longer shipped, the Settings file remains valid and the interface falls back safely.
@@ -49,11 +49,11 @@ Shows the EdgePilot product positioning, current version, local-first principles
 
 ## Saving and recovery
 
-Edits remain pending until **Save changes / Salva modifiche / Enregistrer** is pressed. The footer shows whether changes are pending and provides a reset action. Saving is atomic: a failed save does not replace the last valid preferences.
+Edits remain pending until **Save changes / Salva modifiche / Enregistrer / Guardar cambios** is pressed. The footer shows whether changes are pending and provides a reset action. Saving is atomic: a failed save does not replace the last valid preferences.
 
 Preferences live in `EdgePilot/settings.json` under the user's application-data directory: `%APPDATA%` on Windows and normally `~/.config` on Linux. Missing fields in older files retain defaults; invalid files open Settings with an explanation.
 
-The original v0.2 preview stored languages as `Italian`, `English` and `French`. The current loader accepts those values and migrates them to `it`, `en` and `fr`, so upgrading does not discard existing preferences.
+The original v0.2 preview stored languages as `Italian`, `English` and `French`. The current loader accepts those values and migrates them to `it`, `en` and `fr`, so upgrading does not discard existing preferences. Spanish was added after the extensible locale-code format was introduced and therefore stores directly as `es`.
 
 Tray show/hide is temporary. Saving persists the selected visibility mode. With no tray fallback, closing Settings in hidden mode exits; otherwise the tray or a second launch provides recovery.
 

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -2,10 +2,17 @@
 
 EdgePilot interface text lives in `src/EdgePilot/Assets/Locales`. Each shipped language is one JSON file, embedded at build time.
 
+Current `main` ships:
+
+- `en.json` — English
+- `it.json` — Italiano
+- `fr.json` — Français
+- `es.json` — Español
+
 ## Add a language
 
-1. Copy `src/EdgePilot/Assets/Locales/en.json` to a new file named with the language tag, for example `de.json`, `es.json` or `pt-BR.json`.
-2. Set `_language` to the name of the language written in that language, for example `Deutsch`, `Español` or `Português (Brasil)`.
+1. Copy `src/EdgePilot/Assets/Locales/en.json` to a new file named with the language tag, for example `de.json` or `pt-BR.json`.
+2. Set `_language` to the name of the language written in that language, for example `Deutsch` or `Português (Brasil)`.
 3. Translate the values on the right-hand side. Do not change the keys.
 4. Keep placeholders such as `{0}` and format specifiers such as `{0:0.##}` intact.
 5. Run the repository and localization checks before opening a pull request.
@@ -33,6 +40,8 @@ Automatic mode follows the operating-system UI culture. If a saved language is n
 
 The v0.2 preview originally stored the enum names `Italian`, `English` and `French`. The current preference loader accepts those legacy values and maps them to `it`, `en` and `fr`, so upgrading does not discard existing settings.
 
+Spanish was added after the file-based locale architecture was introduced and therefore needs no special migration value.
+
 ## Rules enforced by CI
 
 - `en.json` is the canonical key set.
@@ -57,7 +66,7 @@ Format specifiers control numeric formatting:
 "drive.capacity.tb": "{0:0.##} TB"
 ```
 
-Keep the format specifier intact. Decimal separators follow the selected locale, so a value can appear as `16.5 TB` in English and `16,5 TB` in Italian or French.
+Keep the format specifier intact. Decimal separators follow the selected locale, so a value can appear as `16.5 TB` in English and `16,5 TB` in Italian, French or Spanish.
 
 ## Short labels
 
@@ -68,3 +77,5 @@ The collapsed notch has limited space. Keep values such as ring captions (`ring.
 The first IT / EN / FR localization foundation was contributed by [@IamArayel](https://github.com/IamArayel) in [PR #5](https://github.com/pricootz/edgepilot/pull/5).
 
 The file-based locale architecture, translation workflow, fallback strategy and repository validation ideas were proposed by [@ArnieGA](https://github.com/ArnieGA) in [PR #8](https://github.com/pricootz/edgepilot/pull/8) and reconciled with the current v0.2 Settings architecture.
+
+The Spanish locale was then contributed by [@ArnieGA](https://github.com/ArnieGA) in [PR #12](https://github.com/pricootz/edgepilot/pull/12), demonstrating that a new shipped language can be added as a single locale JSON file without changing the Settings or localization C# architecture.


### PR DESCRIPTION
## Summary

Bring the documentation in line with what current `main` actually ships after the Spanish locale contribution.

### Updated

- README now lists IT / EN / FR / ES and credits @ArnieGA's Spanish PR #12.
- CHANGELOG records Spanish localization and contributor attribution.
- ROADMAP reflects four shipped locales while keeping Signals explicitly outside current `main`.
- TRANSLATING lists the current locale set and documents #12 as the real-world one-file-language contribution.
- SETTINGS includes Spanish labels and current locale behavior.
- ARCHITECTURE documents the JSON locale discovery, extensible `Language` value object, fallback chain and Settings localization boundaries already present in `main`.
- PRODUCT removes stale v0.1-era language wording and reflects the current v0.2 product surface.

This PR intentionally contains documentation only. It does **not** bring the in-progress Signals implementation into `main`.