### PR TITLE
Add optional Windows 11 glass surface (Flat/Mica/Acrylic)

### DIFF
--- a/src/EdgePilot/Assets/Locales/en.json
+++ b/src/EdgePilot/Assets/Locales/en.json
@@ -148,5 +148,11 @@
   "network.disconnected": "DISCONNECTED",
   "network.noInterface": "No active network interface",
   "network.linkSpeed": "Link speed: {0} Mbps",
-  "network.uptime": "Uptime: {0}"
+  "network.uptime": "Uptime: {0}",
+  "prefs.invalidBackdrop": "Unsupported window surface.",
+  "general.surfaceTitle": "Window surface",
+  "general.surfaceDescription": "Flat keeps EdgePilot's own solid panel. Mica tints the window with your wallpaper; Acrylic shows a live desktop blur — both match a Windows 11 glass desktop.",
+  "surface.flat": "Flat",
+  "surface.mica": "Mica",
+  "surface.acrylic": "Acrylic"
 }

--- a/src/EdgePilot/Assets/Locales/es.json
+++ b/src/EdgePilot/Assets/Locales/es.json
@@ -148,5 +148,11 @@
   "network.disconnected": "DESCONECTADA",
   "network.noInterface": "No hay ninguna interfaz de red activa",
   "network.linkSpeed": "Velocidad del enlace: {0} Mbps",
-  "network.uptime": "Tiempo activo: {0}"
+  "network.uptime": "Tiempo activo: {0}",
+  "prefs.invalidBackdrop": "Superficie de ventana no admitida.",
+  "general.surfaceTitle": "Superficie de la ventana",
+  "general.surfaceDescription": "Plana mantiene el panel sólido propio de EdgePilot. Mica tiñe la ventana con tu fondo de escritorio; Acrílico muestra un desenfoque en vivo del escritorio; ambos combinan con un escritorio de cristal de Windows 11.",
+  "surface.flat": "Plana",
+  "surface.mica": "Mica",
+  "surface.acrylic": "Acrílico"
 }

--- a/src/EdgePilot/Assets/Locales/fr.json
+++ b/src/EdgePilot/Assets/Locales/fr.json
@@ -148,5 +148,11 @@
   "network.disconnected": "DÉCONNECTÉ",
   "network.noInterface": "Aucune interface réseau active",
   "network.linkSpeed": "Vitesse de liaison : {0} Mbps",
-  "network.uptime": "Disponibilité : {0}"
+  "network.uptime": "Disponibilité : {0}",
+  "prefs.invalidBackdrop": "Surface de fenêtre non prise en charge.",
+  "general.surfaceTitle": "Surface de la fenêtre",
+  "general.surfaceDescription": "Plat conserve le panneau opaque d'EdgePilot. Mica teinte la fenêtre avec votre fond d'écran ; Acrylique affiche un flou en direct du bureau ; les deux s'accordent avec un bureau en verre Windows 11.",
+  "surface.flat": "Plat",
+  "surface.mica": "Mica",
+  "surface.acrylic": "Acrylique"
 }

--- a/src/EdgePilot/Assets/Locales/it.json
+++ b/src/EdgePilot/Assets/Locales/it.json
@@ -148,5 +148,11 @@
   "network.disconnected": "DISCONNESSA",
   "network.noInterface": "Nessuna interfaccia di rete attiva",
   "network.linkSpeed": "Velocità collegamento: {0} Mbps",
-  "network.uptime": "Tempo di attività: {0}"
+  "network.uptime": "Tempo di attività: {0}",
+  "prefs.invalidBackdrop": "Superficie della finestra non supportata.",
+  "general.surfaceTitle": "Superficie della finestra",
+  "general.surfaceDescription": "Piatta mantiene il pannello opaco di EdgePilot. Mica tinge la finestra con il tuo sfondo; Acrilico mostra una sfocatura dal vivo del desktop; entrambi si accordano con un desktop di vetro di Windows 11.",
+  "surface.flat": "Piatta",
+  "surface.mica": "Mica",
+  "surface.acrylic": "Acrilico"
 }

--- a/src/EdgePilot/Core/Monitoring/ISystemMetricsProvider.cs
+++ b/src/EdgePilot/Core/Monitoring/ISystemMetricsProvider.cs
@@ -1,5 +1,3 @@
-using EdgePilot.Core;
-
 namespace EdgePilot.Core.Monitoring;
 
 public interface ISystemMetricsProvider

--- a/src/EdgePilot/Core/Monitoring/SystemMonitorService.cs
+++ b/src/EdgePilot/Core/Monitoring/SystemMonitorService.cs
@@ -1,5 +1,3 @@
-using EdgePilot.Core;
-
 namespace EdgePilot.Core.Monitoring;
 
 public sealed class SystemMonitorService

--- a/src/EdgePilot/UI/EdgeNotchGeometry.cs
+++ b/src/EdgePilot/UI/EdgeNotchGeometry.cs
@@ -86,4 +86,48 @@ internal static class EdgeNotchGeometry
         ctx.EndFigure(true);
         return geometry;
     }
+
+    // Same silhouette as BuildRight, flattened to an ordered polygon so it can drive a
+    // Win32 window region (which needs points, not arcs). Design coordinates; the caller
+    // applies the edge transform and DPI scaling.
+    public static Point[] OutlinePoints(double windowWidth, double windowHeight,
+        double depth, double length, int samplesPerArc = 10)
+    {
+        depth = Math.Max(1, depth);
+        length = Math.Max(8, Math.Min(length, windowHeight));
+
+        var top = (windowHeight - length) / 2;
+        var bottom = top + length;
+        var right = windowWidth;
+        var left = right - depth;
+
+        var progress = Math.Clamp((depth - 10) / (88 - 10), 0, 1);
+        var morph = progress * progress * (3 - 2 * progress);
+        var corner = Math.Min(depth, 10 + 10 * morph);
+        var flare = Math.Min(24 * morph,
+            Math.Min(length / 4, Math.Max(0, depth - corner)));
+        corner = Math.Min(corner, Math.Max(0, (length - flare * 2) / 2));
+
+        var bodyTop = top + flare;
+        var bodyBottom = bottom - flare;
+
+        var pts = new List<Point>();
+        void Arc(double cx, double cy, double r, double a0, double a1)
+        {
+            for (var i = 0; i <= samplesPerArc; i++)
+            {
+                var t = a0 + (a1 - a0) * i / samplesPerArc;
+                pts.Add(new Point(cx + r * Math.Cos(t), cy + r * Math.Sin(t)));
+            }
+        }
+
+        Arc(right - flare, top, flare, 0, Math.PI / 2);                 // top-right flare
+        pts.Add(new Point(left + corner, bodyTop));
+        Arc(left + corner, bodyTop + corner, corner, -Math.PI / 2, -Math.PI); // top-left shoulder
+        pts.Add(new Point(left, bodyBottom - corner));
+        Arc(left + corner, bodyBottom - corner, corner, Math.PI, Math.PI / 2); // bottom-left shoulder
+        pts.Add(new Point(right - flare, bodyBottom));
+        Arc(right - flare, bottom, flare, -Math.PI / 2, 0);            // bottom-right flare
+        return pts.ToArray();
+    }
 }

--- a/src/EdgePilot/UI/EdgeWindow.cs
+++ b/src/EdgePilot/UI/EdgeWindow.cs
@@ -5,10 +5,10 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
-using Path = Avalonia.Controls.Shapes.Path;
 using EdgePilot.Core;
 using EdgePilot.Core.Monitoring;
 using EdgePilot.Platform;
+using Path = Avalonia.Controls.Shapes.Path;
 
 namespace EdgePilot.UI;
 
@@ -63,6 +63,8 @@ public sealed class EdgeWindow : Window
     private bool _screensSubscribed;
     private bool _started;
     private NotchDisplayMode _mode;
+    private SettingsBackdrop _backdrop = SettingsBackdrop.Flat;
+    private SettingsThemePreference _settingsTheme = SettingsThemePreference.System;
     private string? _selectedDrive;
     private bool _startAtLogin;
     private Language? _language;
@@ -362,6 +364,96 @@ public sealed class EdgeWindow : Window
         _motionClock.Restart();
         _motionTimer.Start();
     }
+    private void ApplyBackdrop()
+    {
+        var glass = Glass.IsGlass(_backdrop);
+
+        // Mica and Acrylic are real OS backdrops; UpdateNotchVisual clips the window to the
+        // pill (and popup) so the backdrop only shows there. Flat draws its own opaque tab
+        // over a per-pixel-transparent window.
+        var mica = _backdrop == SettingsBackdrop.Mica;
+        TransparencyLevelHint = _backdrop switch
+        {
+            SettingsBackdrop.Mica =>
+                [WindowTransparencyLevel.Mica, WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Transparent],
+            SettingsBackdrop.Acrylic =>
+                [WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Blur, WindowTransparencyLevel.Transparent],
+            _ => [WindowTransparencyLevel.Transparent]
+        };
+
+        // The notch and popup track the settings theme, so light gets dark text and vice
+        // versa — the same flip the settings window does.
+        var dark = ThemeIsDark();
+
+        // Mica is a theme-toned OS base, so the window must render in that theme for the
+        // wallpaper tint to come out light in Light mode; Flat/Acrylic keep the dark notch.
+        RequestedThemeVariant = mica && !dark
+            ? Avalonia.Styling.ThemeVariant.Light
+            : Avalonia.Styling.ThemeVariant.Dark;
+
+        if (glass)
+        {
+            // Pill fill is set per-frame in UpdateNotchVisual (collapsed reads stronger).
+            _notchShape.Stroke = null;
+            _notchShape.StrokeThickness = 0;
+
+            // Mica lays only a thin layer over the OS wallpaper base so it doesn't read as a
+            // solid tab; the light layer is a touch denser so the popup's dark text still reads.
+            _tooltipCard.Background = mica
+                ? new SolidColorBrush(dark ? Color.FromArgb(0x0D, 255, 255, 255) : Color.FromArgb(0x80, 255, 255, 255))
+                : Glass.AcrylicCard(dark);
+            _tooltipCard.BorderBrush = mica ? Glass.MicaCardStroke(dark) : Glass.EdgeBrush(dark);
+            _tooltipCard.BorderThickness = mica ? new Thickness(1) : Glass.EdgeThickness;
+            ApplyTooltipTextColors(dark, lighten: dark && !mica);
+        }
+        else
+        {
+            // Flat is an opaque tab: dark keeps the owner's near-black; light is a clean solid
+            // panel (deliberately not the wallpaper-tinted look a blurred surface would give).
+            _notchShape.Fill = Brush(dark ? "#050608" : "#EDEEF1");
+            _notchShape.Stroke = null;
+            _notchShape.StrokeThickness = 0;
+
+            _tooltipCard.Background = Brush(dark ? "#101318" : "#FBFBFC");
+            _tooltipCard.BorderBrush = Brush(dark ? "#2A3039" : "#D4D7DC");
+            _tooltipCard.BorderThickness = new Thickness(1);
+            ApplyTooltipTextColors(dark, lighten: false);
+        }
+
+        foreach (var ring in new[] { _cpuRing, _ramRing, _diskRing, _networkRing })
+            ring.SetTheme(dark);
+
+        UpdateNotchVisual();
+    }
+
+    // The notch is a shaped window with its own bespoke painting, but it resolves light/dark
+    // from the same shared helper the full-window screens use.
+    private bool ThemeIsDark() => Glass.ResolveDark(_settingsTheme);
+
+    // Light theme uses dark popup text; dark theme keeps the light greys (lifted over Acrylic).
+    private void ApplyTooltipTextColors(bool dark, bool lighten)
+    {
+        if (dark)
+        {
+            _tooltipTitle.Foreground = TextBrush("#858E9B", lighten, 0.40);
+            _tooltipValue.Foreground = Brush("#F5F7FA");
+            _tooltipLine1.Foreground = TextBrush("#C9D0D8", lighten, 0.40);
+            _tooltipLine2.Foreground = TextBrush("#8B93A1", lighten, 0.45);
+            _tooltipLine3.Foreground = TextBrush("#68717E", lighten, 0.50);
+        }
+        else
+        {
+            _tooltipTitle.Foreground = Brush("#55585E");
+            _tooltipValue.Foreground = Brush("#1A1C21");
+            _tooltipLine1.Foreground = Brush("#3A3D42");
+            _tooltipLine2.Foreground = Brush("#55585E");
+            _tooltipLine3.Foreground = Brush("#6A6D73");
+        }
+    }
+
+    private static IBrush TextBrush(string hex, bool lighten, double amount) =>
+        new SolidColorBrush(lighten ? Glass.Lighten(Color.Parse(hex), amount) : Color.Parse(hex));
+
     private void UpdateNotchVisual()
     {
         var p = Math.Clamp(_expansion, 0, 1.025);
@@ -372,6 +464,16 @@ public sealed class EdgeWindow : Window
         geometry.Transform = new MatrixTransform(NotchLayout.Transform(_edge));
         _notchShape.Data = geometry;
         _notchContent.Clip = geometry;
+
+        if (Glass.IsGlass(_backdrop))
+        {
+            // Collapsed and expanded share the same surface layer over the OS backdrop.
+            var dark = ThemeIsDark();
+            _notchShape.Fill = _backdrop == SettingsBackdrop.Mica
+                // Thin layer over the OS Mica wallpaper base so the pill shows the tint, not a solid.
+                ? new SolidColorBrush(dark ? Color.FromArgb(0x0D, 255, 255, 255) : Color.FromArgb(0x40, 255, 255, 255))
+                : Glass.AcrylicCard(dark);
+        }
 
         var contentProgress = Math.Clamp((p - 0.16) / 0.72, 0, 1);
         _notchContent.Opacity = contentProgress;
@@ -388,6 +490,44 @@ public sealed class EdgeWindow : Window
             _tooltipCard.IsVisible = true;
             _tooltipCard.Opacity = Math.Clamp((p - 0.78) / 0.22, 0, 1);
         }
+
+        UpdateRegion();
+    }
+
+    // Clip the window to the pill silhouette (plus the popup when shown) so the OS acrylic
+    // shows only there. Cleared in flat mode, where per-pixel transparency shapes it instead.
+    private void UpdateRegion()
+    {
+        if (!Glass.IsGlass(_backdrop))
+        {
+            NotchRegion.Apply(this, null, null, 0);
+            return;
+        }
+
+        var scale = RenderScaling <= 0 ? 1 : RenderScaling;
+        // Rebuild the outline in design space, apply the same edge transform, then scale.
+        var p = Math.Clamp(_expansion, 0, 1.025);
+        var depth = Lerp(CollapsedDepth, ExpandedDepth, p);
+        var length = Lerp(CollapsedLength, ExpandedLength, p);
+        var matrix = NotchLayout.Transform(_edge);
+        var outline = EdgeNotchGeometry.OutlinePoints(WindowWidth, WindowHeight, depth, length);
+        var pill = new Point[outline.Length];
+        for (var i = 0; i < outline.Length; i++)
+        {
+            var q = outline[i].Transform(matrix);
+            pill[i] = new Point(q.X * scale, q.Y * scale);
+        }
+
+        Rect? tooltip = null;
+        if (_tooltipCard.IsVisible && _hoveredMetric is not null)
+        {
+            var x = Canvas.GetLeft(_tooltipCard);
+            var y = Canvas.GetTop(_tooltipCard);
+            var h = Math.Max(174, _tooltipCard.Bounds.Height);
+            tooltip = new Rect(x * scale, y * scale, 270 * scale, h * scale);
+        }
+
+        NotchRegion.Apply(this, pill, tooltip, 14 * scale);
     }
 
     private int? MetricIndexAt(Point point)
@@ -424,6 +564,7 @@ public sealed class EdgeWindow : Window
         {
             _tooltipCard.Opacity = 0;
             _tooltipCard.IsVisible = false;
+            if (Glass.IsGlass(_backdrop)) UpdateRegion();
             return;
         }
 
@@ -431,6 +572,7 @@ public sealed class EdgeWindow : Window
         PositionTooltip(index.Value);
         _tooltipCard.IsVisible = true;
         _tooltipCard.Opacity = 1;
+        if (Glass.IsGlass(_backdrop)) UpdateRegion();
     }
 
     private void RenderTooltip(int index)
@@ -495,10 +637,14 @@ public sealed class EdgeWindow : Window
 
     public NotchPreferences Preferences => new(_edge, _mode)
     {
-        SelectedDrive = _selectedDrive, StartAtLogin = _startAtLogin,
-        Metrics = _metrics, Sensitivity = _sensitivity,
+        SelectedDrive = _selectedDrive,
+        StartAtLogin = _startAtLogin,
+        Metrics = _metrics,
+        Sensitivity = _sensitivity,
         RefreshIntervalMs = (int)_monitor.RefreshInterval.TotalMilliseconds,
-        Language = _language
+        Language = _language,
+        Backdrop = _backdrop,
+        SettingsTheme = _settingsTheme
     };
 
     public void ApplyPreferences(NotchPreferences preferences)
@@ -514,6 +660,9 @@ public sealed class EdgeWindow : Window
         _metrics = preferences.Metrics;
         _sensitivity = preferences.Sensitivity;
         _language = preferences.Language;
+        _backdrop = preferences.Backdrop;
+        _settingsTheme = preferences.SettingsTheme;
+        ApplyBackdrop();
         Localization.SetLanguage(preferences.Language ?? Localization.DetectSystemLanguage());
         _diskRing.SetCaption(Localization.T("ring.disk"));
         _networkRing.SetCaption(Localization.T("ring.network"));
@@ -623,6 +772,8 @@ public sealed class EdgeWindow : Window
         };
         Canvas.SetLeft(_tooltipCard, x);
         Canvas.SetTop(_tooltipCard, Math.Max(0, y));
+
+        if (Glass.IsGlass(_backdrop)) UpdateRegion();
     }
 
     private Rect HotZoneRect() => NotchLayout.ToScreen(new Rect(

--- a/src/EdgePilot/UI/Glass.cs
+++ b/src/EdgePilot/UI/Glass.cs
@@ -1,0 +1,141 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace EdgePilot.UI;
+
+// The resolved set of brushes for one surface + theme. A screen assigns these to its own
+// panels, cards and text; it never needs to know the Flat/Mica/Acrylic rules itself.
+public sealed record GlassPalette(
+    bool IsGlass, bool IsMica, bool Dark,
+    IBrush Panel, IBrush Card, IBrush CardBorder, Thickness CardBorderThickness,
+    IBrush Line, Color MutedForeground);
+
+// Shared "glass" styling so the settings shell, its cards and the notch/tooltip
+// all read as one frosted surface over the Windows 11 desktop.
+internal static class Glass
+{
+    public static bool IsGlass(SettingsBackdrop backdrop) => backdrop != SettingsBackdrop.Flat;
+
+    // Resolve a theme choice to light/dark; System reads the OS.
+    public static bool ResolveDark(SettingsThemePreference theme) => theme switch
+    {
+        SettingsThemePreference.Light => false,
+        SettingsThemePreference.Dark => true,
+        _ => Application.Current?.PlatformSettings?.GetColorValues().ThemeVariant
+             != Avalonia.Platform.PlatformThemeVariant.Light
+    };
+
+    // The OS backdrop hint for a full-window (rectangular) screen, with fallbacks.
+    public static IReadOnlyList<WindowTransparencyLevel> WindowHint(SettingsBackdrop backdrop) => backdrop switch
+    {
+        SettingsBackdrop.Mica =>
+            [WindowTransparencyLevel.Mica, WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Transparent],
+        SettingsBackdrop.Acrylic =>
+            [WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Blur, WindowTransparencyLevel.Transparent],
+        _ => [WindowTransparencyLevel.None]
+    };
+
+    // The window background: Mica stays transparent so the OS paints the wallpaper base,
+    // Acrylic lays the luminosity veil over the live blur, Flat is a plain solid.
+    public static IBrush WindowBackground(SettingsBackdrop backdrop, bool dark) => backdrop switch
+    {
+        SettingsBackdrop.Mica => Brushes.Transparent,
+        SettingsBackdrop.Acrylic => AcrylicBase(dark),
+        _ => new SolidColorBrush(Color.Parse(dark ? "#121212" : "#F4F4F5"))
+    };
+
+    // Everything a screen paints onto: panels, cards, separators and muted text.
+    public static GlassPalette Palette(SettingsBackdrop backdrop, bool dark)
+    {
+        var glass = IsGlass(backdrop);
+        var mica = backdrop == SettingsBackdrop.Mica;
+        return new GlassPalette(glass, mica, dark,
+            Panel: glass
+                ? (mica ? Brushes.Transparent : AcrylicPanel(dark))
+                : new SolidColorBrush(Color.Parse(dark ? "#151515" : "#FFFFFF")),
+            Card: glass
+                ? (mica ? MicaCard(dark) : AcrylicCard(dark))
+                : new SolidColorBrush(Color.Parse(dark ? "#191919" : "#FFFFFF")),
+            CardBorder: glass
+                ? (mica ? MicaCardStroke(dark) : EdgeBrush(dark))
+                : new SolidColorBrush(Color.Parse(dark ? "#2D2D2D" : "#E2E2E4")),
+            CardBorderThickness: glass && !mica ? EdgeThickness : new Thickness(1),
+            Line: mica ? MicaCardStroke(dark)
+                : glass ? GlassLine(dark) : new SolidColorBrush(Color.Parse(dark ? "#2C2C2C" : "#DDDDDF")),
+            MutedForeground: dark
+                ? (backdrop == SettingsBackdrop.Acrylic ? Lighten(Color.Parse("#8D9096"), 0.45) : Color.Parse("#8D9096"))
+                : glass ? Color.Parse("#44474D") : Color.Parse("#8D9096"));
+    }
+
+    // Bright thin top edge, a defined thicker bottom, no sides — the Windows 11 glass cue.
+    public static Thickness EdgeThickness => new(0, 0.8, 0, 2);
+
+    // Dark theme lifts a card with a bright rim; light theme needs a dark hairline instead,
+    // since a white rim vanishes over a light surface.
+    public static IBrush EdgeBrush(bool dark = true) => dark
+        ? new LinearGradientBrush
+        {
+            StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
+            EndPoint = new RelativePoint(0, 1, RelativeUnit.Relative),
+            GradientStops =
+            {
+                new GradientStop(Color.FromArgb(0x6E, 255, 255, 255), 0.0),
+                new GradientStop(Color.FromArgb(0x0F, 255, 255, 255), 0.35),
+                new GradientStop(Color.FromArgb(0x4A, 255, 255, 255), 1.0)
+            }
+        }
+        : new LinearGradientBrush
+        {
+            StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
+            EndPoint = new RelativePoint(0, 1, RelativeUnit.Relative),
+            GradientStops =
+            {
+                new GradientStop(Color.FromArgb(0x20, 0, 0, 0), 0.0),
+                new GradientStop(Color.FromArgb(0x0A, 0, 0, 0), 0.35),
+                new GradientStop(Color.FromArgb(0x24, 0, 0, 0), 1.0)
+            }
+        };
+
+    // The window-wide luminosity veil that keeps Acrylic text readable over ANY wallpaper.
+    // Windows' own light acrylic clamps the blurred backdrop toward a fixed luminance so
+    // text contrast never depends on what is behind; we can't sample that, so we lay a
+    // white sheet over the live blur. 0x99 (~60%) is the floor: even over a black desktop
+    // the ground stays light enough for dark text, while ~40% of the blur still shows so
+    // the acrylic actually reads as glass. Dark theme keeps light text over the raw blur.
+    public static IBrush AcrylicBase(bool dark = true) =>
+        dark ? Brushes.Transparent : new SolidColorBrush(Color.FromArgb(0x8C, 255, 255, 255));
+
+    // Acrylic keeps the live blur; a thin veil separates chrome from content. Dark veils
+    // with black, light with white, so text keeps its contrast either way.
+    public static IBrush AcrylicPanel(bool dark = true) => new SolidColorBrush(
+        dark ? Color.FromArgb(0x26, 0, 0, 0) : Color.FromArgb(0x7A, 255, 255, 255));
+    public static IBrush AcrylicCard(bool dark = true) => new SolidColorBrush(
+        dark ? Color.FromArgb(0x30, 0, 0, 0) : Color.FromArgb(0x59, 255, 255, 255));
+
+    // Hairline between glass panels: bright over dark, dark over light.
+    public static IBrush GlassLine(bool dark = true) => new SolidColorBrush(
+        dark ? Color.FromArgb(0x24, 255, 255, 255) : Color.FromArgb(0x1F, 0, 0, 0));
+
+    // Mica is the real Windows 11 OS backdrop: opaque, wallpaper-tinted, theme-aware — the
+    // window keeps a transparent background and the OS paints it (see EdgeWindow/SettingsWindow
+    // TransparencyLevelHint). Content then sits on translucent layers over that base, using
+    // the exact WinUI theme values so it matches Windows itself:
+    //   CardBackgroundFillColorDefault  Dark #0DFFFFFF  Light #B3FFFFFF
+    //   CardStrokeColorDefault          Dark #19000000  Light #0F000000
+    public static IBrush MicaCard(bool dark = true) => new SolidColorBrush(
+        dark ? Color.FromArgb(0x0D, 255, 255, 255) : Color.FromArgb(0xB3, 255, 255, 255));
+    public static IBrush MicaCardStroke(bool dark = true) => new SolidColorBrush(
+        dark ? Color.FromArgb(0x19, 0, 0, 0) : Color.FromArgb(0x0F, 0, 0, 0));
+
+    // Nudge a colour toward white by `amount` (0..1), keeping its alpha. Used to keep
+    // muted text readable over the bright blur without flattening everything to pure white.
+    public static Color Lighten(Color c, double amount)
+    {
+        amount = Math.Clamp(amount, 0, 1);
+        return Color.FromArgb(c.A,
+            (byte)(c.R + (255 - c.R) * amount),
+            (byte)(c.G + (255 - c.G) * amount),
+            (byte)(c.B + (255 - c.B) * amount));
+    }
+}

--- a/src/EdgePilot/UI/GlassWindow.cs
+++ b/src/EdgePilot/UI/GlassWindow.cs
@@ -1,0 +1,33 @@
+using Avalonia.Controls;
+using Avalonia.Styling;
+
+namespace EdgePilot.UI;
+
+// Base for any full-window screen that should honour the Flat / Mica / Acrylic surface and
+// the light/dark theme. It does the error-prone OS wiring once — the transparency hint, the
+// window background and the theme variant — then hands the screen a ready GlassPalette to
+// paint its own panels and cards. A new screen only has to:
+//   1. derive from GlassWindow,
+//   2. build its UI and keep references to the panels/cards it wants themed,
+//   3. call ApplySurface(backdrop, theme) after building, and
+//   4. assign the palette brushes in PaintChrome.
+// It never re-implements the surface rules.
+public abstract class GlassWindow : Window
+{
+    // Apply the chosen surface and theme to this window, then repaint the chrome.
+    protected void ApplySurface(SettingsBackdrop backdrop, SettingsThemePreference theme)
+    {
+        RequestedThemeVariant = theme switch
+        {
+            SettingsThemePreference.Light => ThemeVariant.Light,
+            SettingsThemePreference.Dark => ThemeVariant.Dark,
+            _ => ThemeVariant.Default
+        };
+        TransparencyLevelHint = Glass.WindowHint(backdrop);
+        Background = Glass.WindowBackground(backdrop, Glass.ResolveDark(theme));
+        PaintChrome(Glass.Palette(backdrop, Glass.ResolveDark(theme)));
+    }
+
+    // Paint this screen's own elements from the resolved palette.
+    protected abstract void PaintChrome(GlassPalette palette);
+}

--- a/src/EdgePilot/UI/MetricRing.cs
+++ b/src/EdgePilot/UI/MetricRing.cs
@@ -13,6 +13,7 @@ internal sealed class MetricRing : StackPanel
     private const double TrackInset = 4;
 
     private readonly Path _progress;
+    private readonly Ellipse _track;
     private readonly TextBlock _glyph;
     private readonly TextBlock _value;
     private readonly TextBlock _label;
@@ -44,7 +45,7 @@ internal sealed class MetricRing : StackPanel
             Stretch = Stretch.None
         };
 
-        var track = new Ellipse
+        _track = new Ellipse
         {
             Width = Diameter - TrackInset * 2 + 3,
             Height = Diameter - TrackInset * 2 + 3,
@@ -60,7 +61,7 @@ internal sealed class MetricRing : StackPanel
             Height = Diameter,
             HorizontalAlignment = HorizontalAlignment.Center
         };
-        ring.Children.Add(track);
+        ring.Children.Add(_track);
         ring.Children.Add(_progress);
         ring.Children.Add(_glyph);
 
@@ -101,6 +102,16 @@ internal sealed class MetricRing : StackPanel
     }
 
     public void SetGlyph(string glyph) => _glyph.Text = glyph;
+
+    // Recolour for a light or dark acrylic surface so the ring stays legible under both.
+    public void SetTheme(bool dark)
+    {
+        _glyph.Foreground = Brush(dark ? "#F4F6F8" : "#1A1C21");
+        _value.Foreground = Brush(dark ? "#F4F6F8" : "#1A1C21");
+        _label.Foreground = Brush(dark ? "#777F8C" : "#55585E");
+        _progress.Stroke = Brush(dark ? "#F1F4F7" : "#3A3D42");
+        _track.Stroke = Brush(dark ? "#323741" : "#C9CDD4");
+    }
 
     public void SetCaption(string caption) => _label.Text = caption;
 

--- a/src/EdgePilot/UI/NotchLayout.cs
+++ b/src/EdgePilot/UI/NotchLayout.cs
@@ -1,5 +1,4 @@
 using Avalonia;
-using Avalonia.Media;
 
 namespace EdgePilot.UI;
 

--- a/src/EdgePilot/UI/NotchPreferences.cs
+++ b/src/EdgePilot/UI/NotchPreferences.cs
@@ -7,6 +7,7 @@ namespace EdgePilot.UI;
 public enum NotchDisplayMode { Hover, Always, Hidden }
 public enum HoverSensitivity { Precise, Normal, Wide }
 public enum SettingsThemePreference { System, Light, Dark }
+public enum SettingsBackdrop { Flat, Mica, Acrylic }
 
 [Flags]
 public enum VisibleMetrics { Cpu = 1, Memory = 2, Disk = 4, Network = 8, All = 15 }
@@ -22,6 +23,7 @@ public sealed record NotchPreferences(EdgeSide Edge = EdgeSide.Right,
     // Null means "follow the system language".
     public Language? Language { get; init; }
     public SettingsThemePreference SettingsTheme { get; init; } = SettingsThemePreference.System;
+    public SettingsBackdrop Backdrop { get; init; } = SettingsBackdrop.Flat;
 }
 
 public static class PreferenceStore
@@ -48,9 +50,18 @@ public static class PreferenceStore
             throw new InvalidDataException(Localization.T("prefs.invalidMetrics"));
         if (!Enum.IsDefined(value.SettingsTheme))
             throw new InvalidDataException(Localization.T("prefs.invalidTheme"));
+        if (!Enum.IsDefined(value.Backdrop))
+            throw new InvalidDataException(Localization.T("prefs.invalidBackdrop"));
         if (value.Language is { } language && string.IsNullOrWhiteSpace(language.Code))
             throw new InvalidDataException(Localization.T("prefs.invalidLanguage"));
     }
+
+    // Mica/Acrylic are Windows 11 backdrops; on other platforms a stored glass choice
+    // (e.g. from a synced settings file) falls back to Flat so it never persists there.
+    public static NotchPreferences CoerceForPlatform(NotchPreferences value) =>
+        !OperatingSystem.IsWindows() && value.Backdrop != SettingsBackdrop.Flat
+            ? value with { Backdrop = SettingsBackdrop.Flat }
+            : value;
 
     public static NotchPreferences Load(string path)
     {
@@ -58,6 +69,7 @@ public static class PreferenceStore
         var value = JsonSerializer.Deserialize<NotchPreferences>(File.ReadAllText(path), Options)
             ?? throw new InvalidDataException(Localization.T("prefs.emptyFile"));
         Validate(value);
+        value = CoerceForPlatform(value);
 
         // Older v0.2 settings stored enum names such as "Italian". LanguageJsonConverter
         // accepts those names and turns them into locale codes. A locale no longer shipped

--- a/src/EdgePilot/UI/NotchRegion.cs
+++ b/src/EdgePilot/UI/NotchRegion.cs
@@ -1,0 +1,72 @@
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace EdgePilot.UI;
+
+// Clips a window's visible area (and hit area) to the notch silhouette plus, optionally,
+// the tooltip rectangle. This lets the real Windows acrylic backdrop — which always fills
+// a whole window — show only where the pill and popup are, with everything else falling
+// through to the desktop. All coordinates are physical pixels, relative to the client area.
+internal static class NotchRegion
+{
+    private const int WindingFill = 2;
+    private const int RgnOr = 2;
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreatePolygonRgn(POINT[] points, int count, int fillMode);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateRoundRectRgn(int x1, int y1, int x2, int y2, int w, int h);
+
+    [DllImport("gdi32.dll")]
+    private static extern int CombineRgn(IntPtr dest, IntPtr src1, IntPtr src2, int mode);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool DeleteObject(IntPtr obj);
+
+    [DllImport("user32.dll")]
+    private static extern int SetWindowRgn(IntPtr hwnd, IntPtr region, bool redraw);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT { public int X; public int Y; }
+
+    // pill == null clears the region (window returns to a plain rectangle).
+    public static void Apply(Window window, IReadOnlyList<Point>? pill, Rect? tooltip, double cornerPx)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var handle = window.TryGetPlatformHandle()?.Handle ?? IntPtr.Zero;
+        if (handle == IntPtr.Zero) return;
+
+        if (pill is null || pill.Count < 3)
+        {
+            SetWindowRgn(handle, IntPtr.Zero, true);
+            return;
+        }
+
+        var poly = new POINT[pill.Count];
+        for (var i = 0; i < pill.Count; i++)
+            poly[i] = new POINT { X = (int)Math.Round(pill[i].X), Y = (int)Math.Round(pill[i].Y) };
+
+        var region = CreatePolygonRgn(poly, poly.Length, WindingFill);
+        if (region == IntPtr.Zero) return;
+
+        if (tooltip is { } r && r.Width > 1 && r.Height > 1)
+        {
+            var c = (int)Math.Round(cornerPx * 2);
+            var tip = CreateRoundRectRgn(
+                (int)Math.Round(r.X), (int)Math.Round(r.Y),
+                (int)Math.Round(r.Right), (int)Math.Round(r.Bottom), c, c);
+            if (tip != IntPtr.Zero)
+            {
+                CombineRgn(region, region, tip, RgnOr);
+                DeleteObject(tip);
+            }
+        }
+
+        // SetWindowRgn only takes ownership of the region on success; on failure the
+        // window keeps its old region and this handle would leak, so delete it ourselves.
+        if (SetWindowRgn(handle, region, true) == 0)
+            DeleteObject(region);
+    }
+}

--- a/src/EdgePilot/UI/Settings/SettingsPages.cs
+++ b/src/EdgePilot/UI/Settings/SettingsPages.cs
@@ -140,6 +140,13 @@ public sealed partial class SettingsWindow
 
     private Control BuildGeneralPage()
     {
+        // Mica/Acrylic are Windows 11 only; the selector is hidden elsewhere.
+        _surfaceCard = Card(
+            SectionTitle("▦", Localization.T("general.surfaceTitle")),
+            Description(Localization.T("general.surfaceDescription")),
+            SegmentRow(_backdropButtons));
+        _surfaceCard.IsVisible = OperatingSystem.IsWindows();
+
         return Page(
             Localization.T("general.pageTitle"),
             Localization.T("general.pageSubtitle"),
@@ -150,7 +157,8 @@ public sealed partial class SettingsWindow
             Card(
                 SectionTitle("◐", Localization.T("general.themeTitle")),
                 Description(Localization.T("general.themeDescription")),
-                SegmentRow(_themeButtons)));
+                SegmentRow(_themeButtons)),
+            _surfaceCard);
     }
 
     private Control BuildEdgePage()

--- a/src/EdgePilot/UI/SettingsWindow.cs
+++ b/src/EdgePilot/UI/SettingsWindow.cs
@@ -8,7 +8,7 @@ using EdgePilot.Core;
 
 namespace EdgePilot.UI;
 
-public sealed partial class SettingsWindow : Window
+public sealed partial class SettingsWindow : GlassWindow
 {
     private sealed record LanguageChoice(Language? Value, string Caption)
     {
@@ -20,7 +20,7 @@ public sealed partial class SettingsWindow : Window
     private static readonly IBrush AccentSoftBrush = new SolidColorBrush(Color.FromArgb(38, 255, 138, 61));
     private static readonly IBrush PreviewBackgroundBrush = new SolidColorBrush(Color.Parse("#101114"));
     private static readonly IBrush PreviewBorderBrush = new SolidColorBrush(Color.Parse("#404247"));
-    private static readonly IBrush MutedBrush = new SolidColorBrush(Color.Parse("#8D9096"));
+    private static readonly SolidColorBrush MutedBrush = new(Color.Parse("#8D9096"));
     private static readonly VisibleMetrics[] MetricOptions =
         { VisibleMetrics.Cpu, VisibleMetrics.Memory, VisibleMetrics.Disk, VisibleMetrics.Network };
 
@@ -42,6 +42,7 @@ public sealed partial class SettingsWindow : Window
     private readonly Button[] _modeButtons;
     private readonly Button[] _sensitivityButtons;
     private readonly Button[] _themeButtons;
+    private readonly Button[] _backdropButtons;
     private readonly Dictionary<SettingsPage, Button> _navButtons = new();
     private readonly Dictionary<SettingsPage, Control> _pages = new();
     private readonly List<Border> _cards = new();
@@ -50,6 +51,7 @@ public sealed partial class SettingsWindow : Window
     private readonly int[] _intervals = { 500, 1000, 2000, 5000 };
 
     private Border _diskCard = null!;
+    private Border _surfaceCard = null!;
     private Border[] _metricTiles = Array.Empty<Border>();
     private Grid _body = null!;
     private Grid _previewLayout = null!;
@@ -62,6 +64,7 @@ public sealed partial class SettingsWindow : Window
     private NotchDisplayMode _selectedMode;
     private HoverSensitivity _selectedSensitivity;
     private SettingsThemePreference _selectedTheme;
+    private SettingsBackdrop _selectedBackdrop;
     private SettingsPage _selectedPage;
     private bool _ready;
     private bool _darkTheme;
@@ -76,6 +79,7 @@ public sealed partial class SettingsWindow : Window
         _selectedMode = current.Mode;
         _selectedSensitivity = current.Sensitivity;
         _selectedTheme = current.SettingsTheme;
+        _selectedBackdrop = current.Backdrop;
         _initialDrive = current.SelectedDrive;
 
         Title = Localization.T("settings.title");
@@ -204,6 +208,13 @@ public sealed partial class SettingsWindow : Window
             SegmentButton("●", Localization.T("theme.dark"), () => SelectTheme(SettingsThemePreference.Dark))
         ];
 
+        _backdropButtons =
+        [
+            SegmentButton(null, Localization.T("surface.flat"), () => SelectBackdrop(SettingsBackdrop.Flat)),
+            SegmentButton(null, Localization.T("surface.mica"), () => SelectBackdrop(SettingsBackdrop.Mica)),
+            SegmentButton(null, Localization.T("surface.acrylic"), () => SelectBackdrop(SettingsBackdrop.Acrylic))
+        ];
+
         _status = new TextBlock
         {
             Text = warning ?? Localization.T("settings.status.saved"),
@@ -281,6 +292,7 @@ public sealed partial class SettingsWindow : Window
         SelectMode(current.Mode, markDirty: false);
         SelectSensitivity(current.Sensitivity, markDirty: false);
         SelectTheme(current.SettingsTheme, markDirty: false);
+        SelectBackdrop(current.Backdrop, markDirty: false);
         UpdateConditionalSettings();
         var pendingPage = initialPage >= 0 ? initialPage : Interlocked.Exchange(ref _pendingInitialPage, -1);
         var firstPage = Enum.IsDefined(typeof(SettingsPage), pendingPage) ? (SettingsPage)pendingPage : SettingsPage.General;
@@ -342,6 +354,14 @@ public sealed partial class SettingsWindow : Window
         _selectedTheme = theme;
         UpdateSegments(_themeButtons, (int)theme);
         RequestedThemeVariant = ThemeVariantFor(theme);
+        if (markDirty) MarkDirty();
+    }
+
+    private void SelectBackdrop(SettingsBackdrop backdrop, bool markDirty = true)
+    {
+        _selectedBackdrop = backdrop;
+        UpdateSegments(_backdropButtons, (int)backdrop);
+        ApplyTheme();
         if (markDirty) MarkDirty();
     }
 
@@ -428,7 +448,8 @@ public sealed partial class SettingsWindow : Window
             SelectedDrive = (_drive.SelectedItem as DriveChoice)?.Name,
             StartAtLogin = _autostart.IsChecked == true,
             Language = (_language.SelectedItem as LanguageChoice)?.Value,
-            SettingsTheme = _selectedTheme
+            SettingsTheme = _selectedTheme,
+            Backdrop = _selectedBackdrop
         };
     }
 
@@ -449,6 +470,7 @@ public sealed partial class SettingsWindow : Window
         _selectedMode = _savedPreferences.Mode;
         _selectedSensitivity = _savedPreferences.Sensitivity;
         _selectedTheme = _savedPreferences.SettingsTheme;
+        _selectedBackdrop = _savedPreferences.Backdrop;
         _refresh.SelectedIndex = Array.IndexOf(_intervals, _savedPreferences.RefreshIntervalMs);
         for (var i = 0; i < _metrics.Length; i++)
             _metrics[i].IsChecked = _savedPreferences.Metrics.HasFlag(MetricOptions[i]);
@@ -468,7 +490,9 @@ public sealed partial class SettingsWindow : Window
         UpdateSegments(_modeButtons, (int)_selectedMode);
         UpdateSegments(_sensitivityButtons, (int)_selectedSensitivity);
         UpdateSegments(_themeButtons, (int)_selectedTheme);
+        UpdateSegments(_backdropButtons, (int)_selectedBackdrop);
         RequestedThemeVariant = ThemeVariantFor(_selectedTheme);
+        ApplyTheme();
         UpdatePreview();
         UpdateConditionalSettings();
         UpdateMetricTileStates();
@@ -550,23 +574,29 @@ public sealed partial class SettingsWindow : Window
         }
     }
 
-    private void ApplyTheme()
-    {
-        _darkTheme = ActualThemeVariant == ThemeVariant.Dark;
-        Background = Brush(_darkTheme ? "#121212" : "#F4F4F5");
-        _header.Background = Brush(_darkTheme ? "#151515" : "#FFFFFF");
-        _sidebar.Background = Brush(_darkTheme ? "#141414" : "#FAFAFA");
-        _footer.Background = Brush(_darkTheme ? "#151515" : "#FFFFFF");
+    // The surface and theme wiring lives in GlassWindow; this just repaints the shell from
+    // the resolved palette. That is all a new screen has to write, too.
+    private void ApplyTheme() => ApplySurface(_selectedBackdrop, _selectedTheme);
 
-        var line = Brush(_darkTheme ? "#2C2C2C" : "#DDDDDF");
-        _header.BorderBrush = line;
-        _sidebar.BorderBrush = line;
-        _footer.BorderBrush = line;
+    protected override void PaintChrome(GlassPalette p)
+    {
+        _darkTheme = p.Dark;
+        _header.Background = p.Panel;
+        _footer.Background = p.Panel;
+        // The sidebar keeps a slightly deeper flat shade; on glass it matches the panels.
+        _sidebar.Background = p.IsGlass ? p.Panel : Brush(p.Dark ? "#141414" : "#FAFAFA");
+
+        MutedBrush.Color = p.MutedForeground;
+
+        _header.BorderBrush = p.Line;
+        _sidebar.BorderBrush = p.Line;
+        _footer.BorderBrush = p.Line;
 
         foreach (var card in _cards)
         {
-            card.Background = Brush(_darkTheme ? "#191919" : "#FFFFFF");
-            card.BorderBrush = Brush(_darkTheme ? "#2D2D2D" : "#E2E2E4");
+            card.Background = p.Card;
+            card.BorderBrush = p.CardBorder;
+            card.BorderThickness = p.CardBorderThickness;
         }
         UpdateMetricTileStates();
         ShowPage(_selectedPage);

--- a/tests/EdgePilot.UxChecks/Program.cs
+++ b/tests/EdgePilot.UxChecks/Program.cs
@@ -130,6 +130,22 @@ foreach (var edge in Enum.GetValues<EdgeSide>())
 }
 Set(window, "_edge", EdgeSide.Right);
 Call(window, "ConfigureLayout");
+
+// The notch region outline (used to clip the OS backdrop) must stay a sane polygon:
+// enough points to form the pill, hugging the right edge, and never leaving the window.
+foreach (var (depth, length) in new[] { (10d, 82d), (10d, 104d), (50d, 220d), (88d, 360d) })
+{
+    var outline = EdgeNotchGeometry.OutlinePoints(410, 620, depth, length);
+    Check(outline.Length >= 6, $"outline has vertices ({depth},{length})");
+    Check(outline.All(pt => pt.X >= 410 - depth - 0.001 && pt.X <= 410 + 0.001),
+        $"outline stays within depth ({depth},{length})");
+    Check(outline.All(pt => pt.Y >= -0.001 && pt.Y <= 620 + 0.001),
+        $"outline stays within window ({depth},{length})");
+    Check(outline.Any(pt => Math.Abs(pt.X - 410) < 0.001), $"outline meets the screen edge ({depth},{length})");
+    var span = outline.Max(pt => pt.Y) - outline.Min(pt => pt.Y);
+    Check(Math.Abs(span - Math.Min(length, 620)) < 1.0, $"outline spans the pill length ({depth},{length})");
+}
+
 if (args.Length > 0)
 {
     Directory.CreateDirectory(args[0]);
@@ -197,6 +213,20 @@ foreach (var edge in Enum.GetValues<EdgeSide>())
 }
 window.ApplyPreferences(new NotchPreferences());
 
+// The notch seeds the settings window from its live Preferences, so those must echo the
+// full appearance state or a saved theme/backdrop is lost on reopen.
+foreach (var theme in Enum.GetValues<SettingsThemePreference>())
+{
+    window.ApplyPreferences(new NotchPreferences(EdgeSide.Right) { SettingsTheme = theme });
+    Check(window.Preferences.SettingsTheme == theme, "settings theme round trips " + theme);
+}
+foreach (var backdrop in Enum.GetValues<SettingsBackdrop>())
+{
+    window.ApplyPreferences(new NotchPreferences(EdgeSide.Right) { Backdrop = backdrop });
+    Check(window.Preferences.Backdrop == backdrop, "backdrop round trips " + backdrop);
+}
+window.ApplyPreferences(new NotchPreferences());
+
 window.ApplyPreferences(new NotchPreferences { SelectedDrive = "/mnt/dati16" });
 var snapshot = new SystemSnapshot("host", "Ubuntu", 10, 1000, 500, TimeSpan.FromMinutes(10),
     new NetworkSnapshot("eth0", true, 0, 0, 1000), drives, DateTimeOffset.Now);
@@ -253,10 +283,30 @@ try
     try { PreferenceStore.Load(settingsPath); Check(false, "unknown enum rejected"); }
     catch (InvalidDataException) { Check(true, "unknown enum reported"); }
 
+    // Window surface (backdrop): persists on Windows; a stored glass choice coerces to Flat
+    // on other platforms so an unsupported mode never sticks there.
+    foreach (var backdrop in Enum.GetValues<SettingsBackdrop>())
+    {
+        var withBackdrop = new NotchPreferences(EdgeSide.Right) { Backdrop = backdrop };
+        PreferenceStore.Save(settingsPath, withBackdrop);
+        var expected = OperatingSystem.IsWindows() || backdrop == SettingsBackdrop.Flat
+            ? backdrop : SettingsBackdrop.Flat;
+        Check(PreferenceStore.Load(settingsPath).Backdrop == expected, "backdrop persists " + backdrop);
+    }
+    try
+    {
+        PreferenceStore.Save(settingsPath, new NotchPreferences { Backdrop = (SettingsBackdrop)999 });
+        Check(false, "invalid backdrop rejected");
+    }
+    catch (InvalidDataException) { Check(true, "invalid backdrop reported"); }
+    PreferenceStore.Save(settingsPath, new NotchPreferences());
+
     NotchPreferences? applied = null;
     var settings = new SettingsWindow(new NotchPreferences(), value => applied = value,
         storagePath: settingsPath);
     Check(settings.Content is Grid, "settings uses structured shell");
+    Check(((Border)SettingsField(settings, "_surfaceCard")!).IsVisible == OperatingSystem.IsWindows(),
+        "surface selector is gated to Windows");
     var applyButton = (Button)SettingsField(settings, "_applyButton")!;
     var resetButton = (Button)SettingsField(settings, "_resetButton")!;
     var refreshSelector = (ComboBox)SettingsField(settings, "_refresh")!;


### PR DESCRIPTION
Implements the "Window surface" feature request (Flat / Mica / Acrylic), opt-in with Flat as the default.

- Settings window uses the real OS backdrop.
- Edge notch and detail popup are clipped to their shapes via a window region so the frost shows only there.
- Adds en/es/fr/it surface labels; locale parity maintained.

