### PR TITLE
fix: constrain edge input to live EdgePilot regions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
           # A new Unix session must still resolve to the same per-user EdgePilot instance.
           timeout 6s setsid dist/EdgePilot/EdgePilot --settings
           wait "$smoke_pid"
-          dist/EdgePilot/EdgePilot --install
+          bash dist/EdgePilot/install.sh
           test -x "$HOME/.local/share/edgepilot/EdgePilot"
           test -f "$HOME/.local/share/applications/io.github.pricootz.EdgePilot.desktop"
           grep -F 'edgepilot.svg' "$HOME/.local/share/applications/io.github.pricootz.EdgePilot.desktop"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Notch UX regression checks
         run: dotnet run --project tests/EdgePilot.UxChecks --configuration Release
 
+      - name: Input-region regression checks
+        run: dotnet run --project tests/EdgePilot.InputChecks --configuration Release
+
       - name: Localization regression checks
         run: dotnet run --project tests/EdgePilot.LocalizationChecks --configuration Release
 
@@ -119,7 +122,8 @@ jobs:
           timeout 20s xvfb-run -a dist/EdgePilot/EdgePilot --smoke-test &
           smoke_pid=$!
           sleep 2
-          timeout 6s dist/EdgePilot/EdgePilot --settings
+          # A new Unix session must still resolve to the same per-user EdgePilot instance.
+          timeout 6s setsid dist/EdgePilot/EdgePilot --settings
           wait "$smoke_pid"
           dist/EdgePilot/EdgePilot --install
           test -x "$HOME/.local/share/edgepilot/EdgePilot"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install Linux input-region runtime dependency
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxcb-shape0
+          ldconfig -p | grep -F 'libxcb-shape.so.0'
+
       - name: Verify vector brand assets
         if: runner.os == 'Linux'
         shell: bash
@@ -92,7 +100,7 @@ jobs:
           $exe = (Resolve-Path dist/EdgePilot/EdgePilot.exe).Path
           $smoke = Start-Process -FilePath $exe -ArgumentList '--smoke-test' -PassThru -WindowStyle Hidden
           Start-Sleep -Milliseconds 1500
-          if ($smoke.HasExited) { throw 'Primary instance exited prematurely.' }
+          if ($smoke.HasExited) { throw 'Primary instance exited prematurely or native input-region initialization failed.' }
           $second = Start-Process -FilePath $exe -ArgumentList '--settings' -PassThru -WindowStyle Hidden
           if (-not $second.WaitForExit(10000)) {
             $second.Kill()
@@ -103,7 +111,7 @@ jobs:
             $smoke.Kill()
             throw 'Package smoke check timed out.'
           }
-          if ($smoke.ExitCode -ne 0) { throw "Launch failed: $($smoke.ExitCode)" }
+          if ($smoke.ExitCode -ne 0) { throw "Launch/native input-region check failed: $($smoke.ExitCode)" }
           $install = Start-Process -FilePath $exe -ArgumentList '--install' -Wait -PassThru -WindowStyle Hidden
           if ($install.ExitCode -ne 0) { throw 'Per-user installation failed.' }
           $installed = Join-Path $env:LOCALAPPDATA 'Programs/EdgePilot/EdgePilot.exe'

--- a/README.md
+++ b/README.md
@@ -64,17 +64,20 @@ Use the [Releases page](https://github.com/pricootz/edgepilot/releases) for publ
 
 For development builds, open a successful [build workflow](https://github.com/pricootz/edgepilot/actions/workflows/build.yml), then download **EdgePilot-win-x64** or **EdgePilot-linux-x64** under *Artifacts*. Artifact downloads require a GitHub sign-in and expire after 30 days.
 
-Packages include the .NET runtime; no SDK is needed. See the [installation guide](packaging/README.md) for running, installing, upgrading and removing EdgePilot.
+Packages include the .NET runtime; no SDK is needed. Linux X11/XWayland builds also require the small XCB Shape runtime library used to constrain pointer input (`libxcb-shape0` on Debian/Ubuntu/Parrot). See the [installation guide](packaging/README.md) for running, installing, upgrading and removing EdgePilot.
 
 ## Quick start from source
 
-Install the .NET 10 SDK and use a graphical Windows or Linux desktop:
+Install the .NET 10 SDK and use a graphical Windows or Linux desktop. On Debian/Ubuntu/Parrot Linux, install the native XCB Shape dependency first:
 
 ```bash
+sudo apt install libxcb-shape0
 git clone https://github.com/pricootz/edgepilot.git
 cd edgepilot
 dotnet run --project src/EdgePilot/EdgePilot.csproj -c Release -- --settings
 ```
+
+On Windows, skip the `apt` command and run the remaining commands from your preferred Git shell/terminal.
 
 Right-click the notch or use the tray menu to open Settings. Changes remain pending until **Save changes** is pressed. Starting EdgePilot again activates the already-running instance instead of launching a duplicate.
 
@@ -83,6 +86,7 @@ To build and run the regression suites:
 ```bash
 dotnet build src/EdgePilot/EdgePilot.csproj -c Release
 dotnet run --project tests/EdgePilot.UxChecks -c Release
+dotnet run --project tests/EdgePilot.InputChecks -c Release
 dotnet run --project tests/EdgePilot.LocalizationChecks -c Release
 python scripts/check_repository.py
 ```
@@ -91,6 +95,7 @@ python scripts/check_repository.py
 
 - Current packages target **x64**. macOS, ARM packages and headless SSH sessions are not supported targets.
 - Linux transparency, positioning and tray visibility depend on the desktop/compositor. A GNOME AppIndicator extension may be needed.
+- The current Linux desktop path uses X11/XWayland input regions; Avalonia's native Wayland backend is not enabled by this project.
 - Display scaling, multiple monitors and login behavior still need broader real-desktop testing.
 - Disk selection follows a drive letter or mount path, not a hardware serial number.
 - Network interface selection is automatic. Temperatures, GPU and fan readings are not implemented.

--- a/docs/NOTCH-UX.md
+++ b/docs/NOTCH-UX.md
@@ -12,13 +12,14 @@ Pointer exit starts one 450 ms fold timer. Reentry cancels it. Pin prevents fold
 
 `EdgeWindow` intentionally remains larger than the visible notch because the same surface must accommodate spring animation, all four edge orientations and the detail tooltip. Transparency is visual only: the native top-level must also be prevented from receiving pointer input outside EdgePilot's live regions.
 
-The live input model contains only the current notch silhouette, the configured Hover hot-zone in Hover mode, and the visible tooltip plus its bridge. Hidden mode has no live input region. The curved/concave notch is represented by conservative scanline strips rather than its rectangular bounds, so transparent notch corners and shoulders are not accidentally promoted to native input.
+The live input model contains only the current notch silhouette, the configured Hover hot-zone in Hover mode, and the visible tooltip plus its bridge. Hidden mode has no live input region. The curved/concave notch is represented by conservative one-DIP scanline strips rather than its rectangular bounds, so transparent notch corners and shoulders are not accidentally promoted to native input.
 
 Windows and Linux consume this same model:
 
 - Windows applies a real `HWND` window region with `SetWindowRgn`. This is intentionally not based on `HTTRANSPARENT`: Win32 only forwards `HTTRANSPARENT` hit tests through windows owned by the same thread, which is insufficient for browser/desktop applications in other processes.
 - Linux X11/XWayland applies the same live rectangles to the X Shape `ShapeInput` region and updates it during spring motion, tooltip changes, scaling and preference changes.
-- Native rectangle conversion rounds inward. A one-pixel EdgePilot fringe becoming non-interactive is preferable to claiming a pixel that belongs to the application underneath.
+- Logical strip boundaries are quantized to the nearest native pixel. Adjacent strips therefore share a boundary even at fractional DPI instead of creating one-pixel seams through the animated notch.
+- Windows reads the applied region back once and verifies it; Linux sends a checked XCB SHAPE request so native package smoke tests fail if the display server rejects the region.
 - If Windows or Linux cannot establish its safe native region, EdgePilot fails closed by hiding the edge surface instead of leaving a large transparent topmost rectangle that could block the desktop.
 
 The intentional Hover hot-zone remains transparent and interactive: it is the small configured edge area used to wake the collapsed notch. Outside the notch/hot-zone/tooltip/bridge, the large layout window must never receive pointer input.

--- a/docs/NOTCH-UX.md
+++ b/docs/NOTCH-UX.md
@@ -8,16 +8,35 @@ Metric cells use 78 DIP spacing along their primary extent and 10 DIP gaps. The 
 
 Pointer exit starts one 450 ms fold timer. Reentry cancels it. Pin prevents folding, and unpin under the pointer waits for exit. Tooltip bridges cover the gap between the notch and detail card.
 
+## Native input safety
+
+`EdgeWindow` intentionally remains larger than the visible notch because the same surface must accommodate spring animation, all four edge orientations and the detail tooltip. Transparency is visual only: the native top-level must also be prevented from receiving pointer input outside EdgePilot's live regions.
+
+The live input model contains only the current notch, the configured hover hot-zone in Hover mode, and the visible tooltip plus its bridge. Hidden mode has no live input region. Windows and Linux consume this same model:
+
+- Windows returns `HTTRANSPARENT` from `WM_NCHITTEST` everywhere outside the live regions.
+- Linux X11/XWayland applies the live rectangles to the window's X Shape `ShapeInput` region, updating it during spring motion, tooltip changes, scaling and preference changes.
+- If Linux cannot establish a safe X11 input region, EdgePilot fails closed by hiding the edge surface instead of leaving a large transparent topmost rectangle that could block the desktop.
+
+The current Avalonia desktop configuration uses the X11 backend on Linux, including XWayland on Wayland desktops. Avalonia's native Wayland backend is experimental and is not enabled by this project. If a future native Wayland backend is enabled and no equivalent compositor-supported input-region mechanism is available, the same fail-closed rule must be preserved rather than falling back to a rectangular interactive window.
+
+Single-instance protection is separate from pointer routing. The guard is scoped to the current user across OS sessions; a second terminal, desktop launcher or autostart session must activate the existing instance instead of creating another edge surface.
+
 ## Automated checks
 
 Run:
 
 ```bash
 dotnet run --project tests/EdgePilot.UxChecks -c Release
+dotnet run --project tests/EdgePilot.InputChecks -c Release
 ```
 
-The headless suite exercises spring stability and reversals, reveal gating, edge transforms, metric hit targets, tooltip bridges, pin/fold behavior and preferences. An optional output-directory argument writes synthetic preview images, not real desktop screenshots.
+The headless suites exercise spring stability and reversals, reveal gating, edge transforms, metric hit targets, tooltip bridges, pin/fold behavior, preferences and the live input-region model on all four edges. They explicitly verify that the transparent center of the larger native window never belongs to EdgePilot's interaction region.
+
+CI additionally launches the packaged Linux build under Xvfb and requires the X11 input region to initialize successfully. The Linux package check launches a second process in a new Unix session to verify that single-instance protection is user-wide rather than session-local.
 
 ## Desktop checks
 
-Check rapid entry/exit, tooltip transitions, pin/unpin, every edge, mixed DPI and monitor changes on Windows and Ubuntu. Automated headless checks cannot certify compositor transparency, cross-process click-through or flicker in every desktop session.
+Check rapid entry/exit, tooltip transitions, pin/unpin, right-click Settings, every edge, Hidden/Hover/Always, mixed DPI and monitor changes on Windows and Ubuntu. On Linux, verify browser controls directly behind the transparent parts of the EdgePilot window remain clickable while the hover hot-zone still opens the notch.
+
+Automated headless/Xvfb checks cannot certify compositor behavior on every real X11/XWayland desktop. Native Wayland behavior also requires explicit hands-on validation if that backend is enabled in the future.

--- a/docs/NOTCH-UX.md
+++ b/docs/NOTCH-UX.md
@@ -12,13 +12,18 @@ Pointer exit starts one 450 ms fold timer. Reentry cancels it. Pin prevents fold
 
 `EdgeWindow` intentionally remains larger than the visible notch because the same surface must accommodate spring animation, all four edge orientations and the detail tooltip. Transparency is visual only: the native top-level must also be prevented from receiving pointer input outside EdgePilot's live regions.
 
-The live input model contains only the current notch, the configured hover hot-zone in Hover mode, and the visible tooltip plus its bridge. Hidden mode has no live input region. Windows and Linux consume this same model:
+The live input model contains only the current notch silhouette, the configured Hover hot-zone in Hover mode, and the visible tooltip plus its bridge. Hidden mode has no live input region. The curved/concave notch is represented by conservative scanline strips rather than its rectangular bounds, so transparent notch corners and shoulders are not accidentally promoted to native input.
 
-- Windows returns `HTTRANSPARENT` from `WM_NCHITTEST` everywhere outside the live regions.
-- Linux X11/XWayland applies the live rectangles to the window's X Shape `ShapeInput` region, updating it during spring motion, tooltip changes, scaling and preference changes.
-- If Linux cannot establish a safe X11 input region, EdgePilot fails closed by hiding the edge surface instead of leaving a large transparent topmost rectangle that could block the desktop.
+Windows and Linux consume this same model:
 
-The current Avalonia desktop configuration uses the X11 backend on Linux, including XWayland on Wayland desktops. Avalonia's native Wayland backend is experimental and is not enabled by this project. If a future native Wayland backend is enabled and no equivalent compositor-supported input-region mechanism is available, the same fail-closed rule must be preserved rather than falling back to a rectangular interactive window.
+- Windows applies a real `HWND` window region with `SetWindowRgn`. This is intentionally not based on `HTTRANSPARENT`: Win32 only forwards `HTTRANSPARENT` hit tests through windows owned by the same thread, which is insufficient for browser/desktop applications in other processes.
+- Linux X11/XWayland applies the same live rectangles to the X Shape `ShapeInput` region and updates it during spring motion, tooltip changes, scaling and preference changes.
+- Native rectangle conversion rounds inward. A one-pixel EdgePilot fringe becoming non-interactive is preferable to claiming a pixel that belongs to the application underneath.
+- If Windows or Linux cannot establish its safe native region, EdgePilot fails closed by hiding the edge surface instead of leaving a large transparent topmost rectangle that could block the desktop.
+
+The intentional Hover hot-zone remains transparent and interactive: it is the small configured edge area used to wake the collapsed notch. Outside the notch/hot-zone/tooltip/bridge, the large layout window must never receive pointer input.
+
+The current Avalonia desktop configuration uses the X11 backend on Linux, including XWayland on Wayland desktops. The XCB Shape binding requires `libxcb-shape.so.0` (`libxcb-shape0` on Debian/Ubuntu/Parrot), which the package installer checks. Avalonia's native Wayland backend is experimental and is not enabled by this project. If a future native Wayland backend is enabled and no equivalent compositor-supported input-region mechanism is available, the same fail-closed rule must be preserved rather than falling back to a rectangular interactive window.
 
 Single-instance protection is separate from pointer routing. The guard is scoped to the current user across OS sessions; a second terminal, desktop launcher or autostart session must activate the existing instance instead of creating another edge surface.
 
@@ -31,12 +36,12 @@ dotnet run --project tests/EdgePilot.UxChecks -c Release
 dotnet run --project tests/EdgePilot.InputChecks -c Release
 ```
 
-The headless suites exercise spring stability and reversals, reveal gating, edge transforms, metric hit targets, tooltip bridges, pin/fold behavior, preferences and the live input-region model on all four edges. They explicitly verify that the transparent center of the larger native window never belongs to EdgePilot's interaction region.
+The headless suites exercise spring stability and reversals, reveal gating, edge transforms, metric hit targets, tooltip bridges, pin/fold behavior, preferences and the live input-region model on all four edges. They explicitly verify that the transparent center of the larger native window and points inside the old rectangular notch bounds but outside the visible shoulder never belong to EdgePilot's interaction region.
 
-CI additionally launches the packaged Linux build under Xvfb and requires the X11 input region to initialize successfully. The Linux package check launches a second process in a new Unix session to verify that single-instance protection is user-wide rather than session-local.
+CI launches packaged builds on both platforms and requires the native input-region guard to initialize successfully. Ubuntu performs the X11 check under Xvfb with the declared XCB Shape runtime dependency. The Linux package check also launches a second process in a new Unix session to verify that single-instance protection is user-wide rather than session-local.
 
 ## Desktop checks
 
-Check rapid entry/exit, tooltip transitions, pin/unpin, right-click Settings, every edge, Hidden/Hover/Always, mixed DPI and monitor changes on Windows and Ubuntu. On Linux, verify browser controls directly behind the transparent parts of the EdgePilot window remain clickable while the hover hot-zone still opens the notch.
+Check rapid entry/exit, tooltip transitions, pin/unpin, right-click Settings, every edge, Hidden/Hover/Always, mixed DPI and monitor changes on Windows and Ubuntu. On both platforms, place browser controls directly behind transparent portions of the larger EdgePilot layout surface and verify they remain clickable while the configured Hover hot-zone still opens the notch.
 
-Automated headless/Xvfb checks cannot certify compositor behavior on every real X11/XWayland desktop. Native Wayland behavior also requires explicit hands-on validation if that backend is enabled in the future.
+Automated package/Xvfb checks cannot certify compositor/window-manager behavior on every real desktop. Real Windows and Linux X11/XWayland validation is required before #16 is considered resolved. Native Wayland behavior also requires explicit hands-on validation if that backend is enabled in the future.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -12,21 +12,27 @@ Run EdgePilot.exe from the extracted folder. To install for your user and create
 
 Or right-click Install.ps1 and choose Run with PowerShell. Administrator privileges are not required. Installation goes to %LOCALAPPDATA%\Programs\EdgePilot. Start EdgePilot from the Start menu.
 
+EdgePilot constrains its native HWND to the notch, configured Hover hot-zone and visible tooltip/bridge. Transparent parts of the larger layout surface are therefore outside the native window region and cannot block mouse input to applications underneath.
+
 ## Linux / Ubuntu
 
 A graphical desktop session and its native libraries are required; this is not a terminal-only server application.
 
+EdgePilot requires the XCB Shape runtime library so its X11/XWayland top-level can expose only the intended pointer-input region. On Debian, Ubuntu and Parrot install it with:
+
 ```bash
-./EdgePilot
+sudo apt install libxcb-shape0
 ```
 
-To install for your user and create an Applications launcher:
+Then install EdgePilot for your user:
 
 ```bash
 bash install.sh
 ```
 
-Installation goes to ~/.local/share/edgepilot. X11/XWayland, fontconfig and the desktop's native dependencies are still needed. Linux desktop/compositor support varies. GNOME may require an AppIndicator extension for tray visibility.
+`install.sh` checks for `libxcb-shape.so.0` and stops with an actionable message if it is missing. Installation goes to ~/.local/share/edgepilot. X11/XWayland, fontconfig and the desktop's native dependencies are still needed. Linux desktop/compositor support varies. GNOME may require an AppIndicator extension for tray visibility.
+
+On X11 and the default XWayland path, EdgePilot uses the X Shape `ShapeInput` region. If the running backend cannot provide a safe native input region, EdgePilot deliberately hides the edge surface rather than leave a large transparent topmost rectangle capable of blocking the desktop.
 
 ## Settings and recovery
 

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,5 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 package_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+has_xcb_shape=0
+ldconfig_bin="$(command -v ldconfig || true)"
+if [[ -z "$ldconfig_bin" && -x /sbin/ldconfig ]]; then
+  ldconfig_bin=/sbin/ldconfig
+fi
+if [[ -n "$ldconfig_bin" ]]; then
+  ldconfig_output="$($ldconfig_bin -p 2>/dev/null || true)"
+  if grep -Fq 'libxcb-shape.so.0' <<<"$ldconfig_output"; then
+    has_xcb_shape=1
+  fi
+fi
+if [[ $has_xcb_shape -eq 0 ]]; then
+  for libdir in /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /lib64 /usr/lib64; do
+    if [[ -e "$libdir/libxcb-shape.so.0" ]]; then
+      has_xcb_shape=1
+      break
+    fi
+  done
+fi
+
+if [[ $has_xcb_shape -eq 0 ]]; then
+  cat >&2 <<'EOF'
+EdgePilot requires libxcb-shape.so.0 to keep transparent desktop areas click-through on Linux.
+Debian / Ubuntu / Parrot: sudo apt install libxcb-shape0
+Install that package, then run install.sh again.
+EOF
+  exit 1
+fi
+
 "$package_dir/EdgePilot" --install
 printf '%s\n' 'EdgePilot installed. Open it from the Applications menu.'

--- a/src/EdgePilot/App.cs
+++ b/src/EdgePilot/App.cs
@@ -93,7 +93,16 @@ public sealed class App : Application
             window.Opened += (_, _) =>
             {
                 if (desktop.Args?.Contains("--smoke-test") == true)
+                {
+                    if (OperatingSystem.IsLinux() && !window.HasSafePlatformInput)
+                    {
+                        Console.Error.WriteLine("EdgePilot could not establish a safe Linux input region.");
+                        Environment.ExitCode = 2;
+                        desktop.Shutdown();
+                        return;
+                    }
                     DispatcherTimer.RunOnce(() => desktop.Shutdown(), TimeSpan.FromSeconds(8));
+                }
                 if ((preferences.Mode == NotchDisplayMode.Hidden &&
                     (!window.HasTray || desktop.Args?.Contains("--autostart") != true)) || warning is not null ||
                     desktop.Args?.Contains("--settings") == true || desktop.Args?.Contains("--smoke-test") == true)

--- a/src/EdgePilot/App.cs
+++ b/src/EdgePilot/App.cs
@@ -94,11 +94,13 @@ public sealed class App : Application
             {
                 if (desktop.Args?.Contains("--smoke-test") == true)
                 {
-                    if (OperatingSystem.IsLinux() && !window.HasSafePlatformInput)
+                    if ((OperatingSystem.IsWindows() || OperatingSystem.IsLinux()) && !window.HasSafePlatformInput)
                     {
-                        Console.Error.WriteLine("EdgePilot could not establish a safe Linux input region.");
+                        Console.Error.WriteLine("EdgePilot could not establish a safe native input region.");
                         Environment.ExitCode = 2;
-                        desktop.Shutdown();
+                        // Shutting down synchronously from Opened can tear down Avalonia while its
+                        // desktop lifetime is still entering StartCore. Defer by one dispatcher turn.
+                        DispatcherTimer.RunOnce(() => desktop.Shutdown(), TimeSpan.FromMilliseconds(1));
                         return;
                     }
                     DispatcherTimer.RunOnce(() => desktop.Shutdown(), TimeSpan.FromSeconds(8));

--- a/src/EdgePilot/Platform/PlatformInputRegion.cs
+++ b/src/EdgePilot/Platform/PlatformInputRegion.cs
@@ -20,6 +20,7 @@ internal sealed class PlatformInputRegion : IDisposable
     private bool _windowsInitializationAttempted;
     private bool _x11InitializationAttempted;
     private bool _ready;
+    private int? _lastNativeRegionHash;
 
     public PlatformInputRegion(Window window) => _window = window;
 
@@ -27,41 +28,35 @@ internal sealed class PlatformInputRegion : IDisposable
 
     public bool TryApply(IReadOnlyList<Rect> logicalRects, double scaling, Size logicalWindowSize)
     {
+        var rectangles = ToNativeRectangles(logicalRects, scaling, logicalWindowSize);
+        var hash = HashNativeRectangles(rectangles);
+        if (_ready && _lastNativeRegionHash == hash)
+            return true;
+
+        bool applied;
         if (OperatingSystem.IsWindows())
-            return TryApplyWindows(logicalRects, scaling, logicalWindowSize);
-        if (OperatingSystem.IsLinux())
-            return TryApplyX11(logicalRects, scaling, logicalWindowSize);
-        return true;
+            applied = TryApplyWindows(rectangles);
+        else if (OperatingSystem.IsLinux())
+            applied = TryApplyX11(rectangles);
+        else
+            return true;
+
+        if (applied)
+            _lastNativeRegionHash = hash;
+        return applied;
     }
 
-    private bool TryApplyWindows(IReadOnlyList<Rect> logicalRects, double scaling, Size logicalWindowSize)
+    private bool TryApplyWindows(NativeRect[] rectangles)
     {
         if (!EnsureWindows())
             return false;
 
-        var rectangles = ToNativeRectangles(logicalRects, scaling, logicalWindowSize);
-        var region = CreateRectRgn(0, 0, 0, 0);
-        if (region == IntPtr.Zero)
-            return FailWindows("EdgePilot could not create the Windows input-safe window region.");
-
+        IntPtr region = IntPtr.Zero;
         try
         {
-            foreach (var rect in rectangles)
-            {
-                var part = CreateRectRgn(rect.Left, rect.Top, rect.Right, rect.Bottom);
-                if (part == IntPtr.Zero)
-                    return FailWindows("EdgePilot could not create a Windows region segment.");
-
-                try
-                {
-                    if (CombineRgn(region, region, part, RgnOr) == ErrorRegion)
-                        return FailWindows("EdgePilot could not combine the Windows input region.");
-                }
-                finally
-                {
-                    DeleteObject(part);
-                }
-            }
+            region = CreateWindowsRegion(rectangles);
+            if (region == IntPtr.Zero)
+                return FailWindows("EdgePilot could not create the Windows input-safe window region.");
 
             // SetWindowRgn transfers ownership of HRGN to USER32 on success. Unlike
             // HTTRANSPARENT, the HWND simply does not exist for hit testing outside this region,
@@ -81,6 +76,47 @@ internal sealed class PlatformInputRegion : IDisposable
         {
             if (region != IntPtr.Zero)
                 DeleteObject(region);
+        }
+    }
+
+    private static IntPtr CreateWindowsRegion(NativeRect[] rectangles)
+    {
+        if (rectangles.Length == 0)
+            return CreateRectRgn(0, 0, 0, 0);
+
+        var rectSize = Marshal.SizeOf<NativeRect>();
+        var headerSize = Marshal.SizeOf<RegionDataHeader>();
+        var bufferSize = checked(headerSize + rectSize * rectangles.Length);
+        var buffer = Marshal.AllocHGlobal(bufferSize);
+        try
+        {
+            var bound = new NativeRect(
+                rectangles.Min(rect => rect.Left),
+                rectangles.Min(rect => rect.Top),
+                rectangles.Max(rect => rect.Right),
+                rectangles.Max(rect => rect.Bottom));
+            var header = new RegionDataHeader
+            {
+                Size = (uint)headerSize,
+                Type = RectanglesRegionType,
+                Count = (uint)rectangles.Length,
+                RegionSize = (uint)(rectSize * rectangles.Length),
+                Bound = bound
+            };
+            Marshal.StructureToPtr(header, buffer, false);
+
+            var cursor = IntPtr.Add(buffer, headerSize);
+            foreach (var rect in rectangles)
+            {
+                Marshal.StructureToPtr(rect, cursor, false);
+                cursor = IntPtr.Add(cursor, rectSize);
+            }
+
+            return ExtCreateRegion(IntPtr.Zero, (uint)bufferSize, buffer);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
         }
     }
 
@@ -108,15 +144,15 @@ internal sealed class PlatformInputRegion : IDisposable
     {
         System.Diagnostics.Trace.WriteLine(message);
         _ready = false;
+        _lastNativeRegionHash = null;
         return false;
     }
 
-    private bool TryApplyX11(IReadOnlyList<Rect> logicalRects, double scaling, Size logicalWindowSize)
+    private bool TryApplyX11(NativeRect[] nativeRects)
     {
         if (!EnsureX11())
             return false;
 
-        var nativeRects = ToNativeRectangles(logicalRects, scaling, logicalWindowSize);
         var rectangles = nativeRects.Select(rect => new XRectangle
         {
             X = (short)Math.Clamp(rect.Left, short.MinValue, short.MaxValue),
@@ -136,6 +172,7 @@ internal sealed class PlatformInputRegion : IDisposable
             {
                 System.Diagnostics.Trace.WriteLine("EdgePilot lost the X11 connection used for input-region safety.");
                 _ready = false;
+                _lastNativeRegionHash = null;
                 return false;
             }
             return true;
@@ -144,6 +181,7 @@ internal sealed class PlatformInputRegion : IDisposable
         {
             System.Diagnostics.Trace.WriteLine($"EdgePilot could not apply the X11 input region: {ex.Message}");
             _ready = false;
+            _lastNativeRegionHash = null;
             return false;
         }
     }
@@ -227,22 +265,40 @@ internal sealed class PlatformInputRegion : IDisposable
                 || !double.IsFinite(rect.Width) || !double.IsFinite(rect.Height))
                 continue;
 
-            var left = Math.Clamp((int)Math.Floor(rect.Left * scaling), 0, windowWidth);
-            var top = Math.Clamp((int)Math.Floor(rect.Top * scaling), 0, windowHeight);
-            var right = Math.Clamp((int)Math.Ceiling(rect.Right * scaling), 0, windowWidth);
-            var bottom = Math.Clamp((int)Math.Ceiling(rect.Bottom * scaling), 0, windowHeight);
+            var left = Math.Clamp((int)Math.Ceiling(rect.Left * scaling), 0, windowWidth);
+            var top = Math.Clamp((int)Math.Ceiling(rect.Top * scaling), 0, windowHeight);
+            var right = Math.Clamp((int)Math.Floor(rect.Right * scaling), 0, windowWidth);
+            var bottom = Math.Clamp((int)Math.Floor(rect.Bottom * scaling), 0, windowHeight);
             if (right <= left || bottom <= top)
                 continue;
 
+            // Inset rounding is deliberate. The native region must never grow beyond the logical
+            // live area because a one-pixel missed EdgePilot fringe is safer than stealing a click
+            // from the application underneath.
             result.Add(new NativeRect(left, top, right, bottom));
         }
 
         return result.ToArray();
     }
 
+    private static int HashNativeRectangles(NativeRect[] rectangles)
+    {
+        var hash = new HashCode();
+        hash.Add(rectangles.Length);
+        foreach (var rect in rectangles)
+        {
+            hash.Add(rect.Left);
+            hash.Add(rect.Top);
+            hash.Add(rect.Right);
+            hash.Add(rect.Bottom);
+        }
+        return hash.ToHashCode();
+    }
+
     public void Dispose()
     {
         _ready = false;
+        _lastNativeRegionHash = null;
         _hwnd = IntPtr.Zero;
         _xid = 0;
         DisconnectX11();
@@ -261,10 +317,34 @@ internal sealed class PlatformInputRegion : IDisposable
         _connection = IntPtr.Zero;
     }
 
-    private readonly record struct NativeRect(int Left, int Top, int Right, int Bottom);
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
 
-    private const int RgnOr = 2;
-    private const int ErrorRegion = 0;
+        public NativeRect(int left, int top, int right, int bottom)
+        {
+            Left = left;
+            Top = top;
+            Right = right;
+            Bottom = bottom;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RegionDataHeader
+    {
+        public uint Size;
+        public uint Type;
+        public uint Count;
+        public uint RegionSize;
+        public NativeRect Bound;
+    }
+
+    private const uint RectanglesRegionType = 1;
     private const byte ShapeSet = 0;
     private const byte ShapeInput = 2;
     private const byte Unsorted = 0;
@@ -308,7 +388,7 @@ internal sealed class PlatformInputRegion : IDisposable
     private static extern IntPtr CreateRectRgn(int left, int top, int right, int bottom);
 
     [DllImport("gdi32.dll")]
-    private static extern int CombineRgn(IntPtr destination, IntPtr source1, IntPtr source2, int combineMode);
+    private static extern IntPtr ExtCreateRegion(IntPtr transform, uint dataSize, IntPtr regionData);
 
     [DllImport("gdi32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/EdgePilot/Platform/PlatformInputRegion.cs
+++ b/src/EdgePilot/Platform/PlatformInputRegion.cs
@@ -1,0 +1,179 @@
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Platform;
+
+namespace EdgePilot.Platform;
+
+/// <summary>
+/// Limits the native Linux top-level input shape to EdgePilot's live interaction areas.
+/// Avalonia renders transparent pixels, but an X11 top-level remains rectangular for pointer
+/// input unless the X Shape input region is explicitly constrained.
+/// </summary>
+internal sealed class PlatformInputRegion : IDisposable
+{
+    private readonly Window _window;
+    private IntPtr _display;
+    private IntPtr _xid;
+    private bool _initializationAttempted;
+    private bool _ready;
+
+    public PlatformInputRegion(Window window) => _window = window;
+
+    public bool IsReady => !OperatingSystem.IsLinux() || _ready;
+
+    public bool TryApply(IReadOnlyList<Rect> logicalRects, double scaling, Size logicalWindowSize)
+    {
+        if (!OperatingSystem.IsLinux())
+            return true;
+
+        if (!EnsureX11())
+            return false;
+
+        scaling = scaling > 0 && double.IsFinite(scaling) ? scaling : 1;
+        var windowWidth = Math.Max(0, (int)Math.Ceiling(logicalWindowSize.Width * scaling));
+        var windowHeight = Math.Max(0, (int)Math.Ceiling(logicalWindowSize.Height * scaling));
+        var rectangles = ToXRectangles(logicalRects, scaling, windowWidth, windowHeight);
+
+        // XShapeCombineRectangles with one empty rectangle produces an empty ShapeInput
+        // region. Passing a stable array also avoids platform marshalling edge cases for
+        // zero-length arrays.
+        if (rectangles.Length == 0)
+            rectangles = [new XRectangle()];
+
+        try
+        {
+            XShapeCombineRectangles(_display, _xid, ShapeInput, 0, 0,
+                rectangles, rectangles.Length, ShapeSet, Unsorted);
+            XFlush(_display);
+            return true;
+        }
+        catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
+        {
+            System.Diagnostics.Trace.WriteLine($"EdgePilot could not apply the X11 input region: {ex.Message}");
+            _ready = false;
+            return false;
+        }
+    }
+
+    private bool EnsureX11()
+    {
+        if (_ready)
+            return true;
+        if (_initializationAttempted)
+            return false;
+
+        _initializationAttempted = true;
+        try
+        {
+            var handle = _window.TryGetPlatformHandle();
+            if (handle is null || !string.Equals(handle.HandleDescriptor, "XID", StringComparison.OrdinalIgnoreCase)
+                || handle.Handle == IntPtr.Zero)
+            {
+                System.Diagnostics.Trace.WriteLine("EdgePilot input-region safety requires an X11/XWayland XID; the edge surface will not accept input on this backend.");
+                return false;
+            }
+
+            _display = XOpenDisplay(IntPtr.Zero);
+            if (_display == IntPtr.Zero)
+            {
+                System.Diagnostics.Trace.WriteLine("EdgePilot could not open the X11 display for input-region safety.");
+                return false;
+            }
+
+            if (XShapeQueryExtension(_display, out _, out _) == 0)
+            {
+                System.Diagnostics.Trace.WriteLine("EdgePilot requires the X Shape extension to constrain the Linux edge input region.");
+                XCloseDisplay(_display);
+                _display = IntPtr.Zero;
+                return false;
+            }
+
+            _xid = handle.Handle;
+            _ready = true;
+            return true;
+        }
+        catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
+        {
+            System.Diagnostics.Trace.WriteLine($"EdgePilot could not initialize X11 input-region safety: {ex.Message}");
+            if (_display != IntPtr.Zero)
+            {
+                try { XCloseDisplay(_display); } catch { }
+                _display = IntPtr.Zero;
+            }
+            return false;
+        }
+    }
+
+    private static XRectangle[] ToXRectangles(IReadOnlyList<Rect> logicalRects, double scaling,
+        int windowWidth, int windowHeight)
+    {
+        var result = new List<XRectangle>(logicalRects.Count);
+        foreach (var rect in logicalRects)
+        {
+            if (rect.Width <= 0 || rect.Height <= 0 || !double.IsFinite(rect.X) || !double.IsFinite(rect.Y)
+                || !double.IsFinite(rect.Width) || !double.IsFinite(rect.Height))
+                continue;
+
+            var left = Math.Clamp((int)Math.Floor(rect.Left * scaling), 0, windowWidth);
+            var top = Math.Clamp((int)Math.Floor(rect.Top * scaling), 0, windowHeight);
+            var right = Math.Clamp((int)Math.Ceiling(rect.Right * scaling), 0, windowWidth);
+            var bottom = Math.Clamp((int)Math.Ceiling(rect.Bottom * scaling), 0, windowHeight);
+            if (right <= left || bottom <= top)
+                continue;
+
+            result.Add(new XRectangle
+            {
+                X = (short)Math.Clamp(left, short.MinValue, short.MaxValue),
+                Y = (short)Math.Clamp(top, short.MinValue, short.MaxValue),
+                Width = (ushort)Math.Clamp(right - left, 0, ushort.MaxValue),
+                Height = (ushort)Math.Clamp(bottom - top, 0, ushort.MaxValue)
+            });
+        }
+        return result.ToArray();
+    }
+
+    public void Dispose()
+    {
+        _ready = false;
+        _xid = IntPtr.Zero;
+        if (_display == IntPtr.Zero)
+            return;
+
+        try { XCloseDisplay(_display); }
+        catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
+        {
+            System.Diagnostics.Trace.WriteLine(ex);
+        }
+        _display = IntPtr.Zero;
+    }
+
+    private const int ShapeInput = 2;
+    private const int ShapeSet = 0;
+    private const int Unsorted = 0;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XRectangle
+    {
+        public short X;
+        public short Y;
+        public ushort Width;
+        public ushort Height;
+    }
+
+    [DllImport("libX11.so.6")]
+    private static extern IntPtr XOpenDisplay(IntPtr displayName);
+
+    [DllImport("libX11.so.6")]
+    private static extern int XCloseDisplay(IntPtr display);
+
+    [DllImport("libX11.so.6")]
+    private static extern int XFlush(IntPtr display);
+
+    [DllImport("libXext.so.6")]
+    private static extern int XShapeQueryExtension(IntPtr display, out int eventBase, out int errorBase);
+
+    [DllImport("libXext.so.6")]
+    private static extern void XShapeCombineRectangles(IntPtr display, IntPtr destination, int destinationKind,
+        int xOffset, int yOffset, [In] XRectangle[] rectangles, int rectangleCount, int operation, int ordering);
+}

--- a/src/EdgePilot/Platform/PlatformInputRegion.cs
+++ b/src/EdgePilot/Platform/PlatformInputRegion.cs
@@ -94,7 +94,7 @@ internal sealed class PlatformInputRegion : IDisposable
                     return false;
                 }
 
-                var version = Marshal.PtrToStructure<XcbShapeQueryVersionReply>(reply);
+                var version = Marshal.PtrToStructure<XcbShapeVersionReply>(reply);
                 if (version.MajorVersion < 1 || (version.MajorVersion == 1 && version.MinorVersion < 1))
                 {
                     System.Diagnostics.Trace.WriteLine($"EdgePilot requires X Shape 1.1 for ShapeInput; server reports {version.MajorVersion}.{version.MinorVersion}.");
@@ -191,7 +191,7 @@ internal sealed class PlatformInputRegion : IDisposable
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct XcbShapeQueryVersionReply
+    private struct XcbShapeVersionReply
     {
         public byte ResponseType;
         public byte Pad0;

--- a/src/EdgePilot/Platform/PlatformInputRegion.cs
+++ b/src/EdgePilot/Platform/PlatformInputRegion.cs
@@ -6,34 +6,124 @@ using Avalonia.Platform;
 namespace EdgePilot.Platform;
 
 /// <summary>
-/// Limits the native Linux top-level input shape to EdgePilot's live interaction areas.
-/// Avalonia renders transparent pixels, but an X11 top-level remains rectangular for pointer
-/// input unless the X Shape input region is explicitly constrained.
+/// Constrains the native top-level to EdgePilot's live interaction areas.
+/// Visual transparency is not an input-routing guarantee: Windows needs a real HWND region,
+/// while X11/XWayland needs an explicit ShapeInput region.
 /// </summary>
 internal sealed class PlatformInputRegion : IDisposable
 {
     private readonly Window _window;
+
+    private IntPtr _hwnd;
     private IntPtr _connection;
     private uint _xid;
-    private bool _initializationAttempted;
+    private bool _windowsInitializationAttempted;
+    private bool _x11InitializationAttempted;
     private bool _ready;
 
     public PlatformInputRegion(Window window) => _window = window;
 
-    public bool IsReady => !OperatingSystem.IsLinux() || _ready;
+    public bool IsReady => !OperatingSystem.IsWindows() && !OperatingSystem.IsLinux() || _ready;
 
     public bool TryApply(IReadOnlyList<Rect> logicalRects, double scaling, Size logicalWindowSize)
     {
-        if (!OperatingSystem.IsLinux())
-            return true;
+        if (OperatingSystem.IsWindows())
+            return TryApplyWindows(logicalRects, scaling, logicalWindowSize);
+        if (OperatingSystem.IsLinux())
+            return TryApplyX11(logicalRects, scaling, logicalWindowSize);
+        return true;
+    }
 
+    private bool TryApplyWindows(IReadOnlyList<Rect> logicalRects, double scaling, Size logicalWindowSize)
+    {
+        if (!EnsureWindows())
+            return false;
+
+        var rectangles = ToNativeRectangles(logicalRects, scaling, logicalWindowSize);
+        var region = CreateRectRgn(0, 0, 0, 0);
+        if (region == IntPtr.Zero)
+            return FailWindows("EdgePilot could not create the Windows input-safe window region.");
+
+        try
+        {
+            foreach (var rect in rectangles)
+            {
+                var part = CreateRectRgn(rect.Left, rect.Top, rect.Right, rect.Bottom);
+                if (part == IntPtr.Zero)
+                    return FailWindows("EdgePilot could not create a Windows region segment.");
+
+                try
+                {
+                    if (CombineRgn(region, region, part, RgnOr) == ErrorRegion)
+                        return FailWindows("EdgePilot could not combine the Windows input region.");
+                }
+                finally
+                {
+                    DeleteObject(part);
+                }
+            }
+
+            // SetWindowRgn transfers ownership of HRGN to USER32 on success. Unlike
+            // HTTRANSPARENT, the HWND simply does not exist for hit testing outside this region,
+            // so clicks can reach windows owned by other applications/processes.
+            if (SetWindowRgn(_hwnd, region, true) == 0)
+                return FailWindows("EdgePilot could not apply the Windows input-safe window region.");
+
+            region = IntPtr.Zero;
+            _ready = true;
+            return true;
+        }
+        catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
+        {
+            return FailWindows($"EdgePilot could not apply the Windows input region: {ex.Message}");
+        }
+        finally
+        {
+            if (region != IntPtr.Zero)
+                DeleteObject(region);
+        }
+    }
+
+    private bool EnsureWindows()
+    {
+        if (_ready && _hwnd != IntPtr.Zero)
+            return true;
+        if (_windowsInitializationAttempted)
+            return false;
+
+        _windowsInitializationAttempted = true;
+        var handle = _window.TryGetPlatformHandle();
+        if (handle is null || !string.Equals(handle.HandleDescriptor, "HWND", StringComparison.OrdinalIgnoreCase)
+            || handle.Handle == IntPtr.Zero)
+        {
+            System.Diagnostics.Trace.WriteLine("EdgePilot input-region safety requires a valid HWND on Windows.");
+            return false;
+        }
+
+        _hwnd = handle.Handle;
+        return true;
+    }
+
+    private bool FailWindows(string message)
+    {
+        System.Diagnostics.Trace.WriteLine(message);
+        _ready = false;
+        return false;
+    }
+
+    private bool TryApplyX11(IReadOnlyList<Rect> logicalRects, double scaling, Size logicalWindowSize)
+    {
         if (!EnsureX11())
             return false;
 
-        scaling = scaling > 0 && double.IsFinite(scaling) ? scaling : 1;
-        var windowWidth = Math.Max(0, (int)Math.Ceiling(logicalWindowSize.Width * scaling));
-        var windowHeight = Math.Max(0, (int)Math.Ceiling(logicalWindowSize.Height * scaling));
-        var rectangles = ToXRectangles(logicalRects, scaling, windowWidth, windowHeight);
+        var nativeRects = ToNativeRectangles(logicalRects, scaling, logicalWindowSize);
+        var rectangles = nativeRects.Select(rect => new XRectangle
+        {
+            X = (short)Math.Clamp(rect.Left, short.MinValue, short.MaxValue),
+            Y = (short)Math.Clamp(rect.Top, short.MinValue, short.MaxValue),
+            Width = (ushort)Math.Clamp(rect.Right - rect.Left, 0, ushort.MaxValue),
+            Height = (ushort)Math.Clamp(rect.Bottom - rect.Top, 0, ushort.MaxValue)
+        }).ToArray();
 
         try
         {
@@ -60,12 +150,12 @@ internal sealed class PlatformInputRegion : IDisposable
 
     private bool EnsureX11()
     {
-        if (_ready)
+        if (_ready && _connection != IntPtr.Zero)
             return true;
-        if (_initializationAttempted)
+        if (_x11InitializationAttempted)
             return false;
 
-        _initializationAttempted = true;
+        _x11InitializationAttempted = true;
         try
         {
             var handle = _window.TryGetPlatformHandle();
@@ -80,7 +170,7 @@ internal sealed class PlatformInputRegion : IDisposable
             if (_connection == IntPtr.Zero || XcbConnectionHasError(_connection) != 0)
             {
                 System.Diagnostics.Trace.WriteLine("EdgePilot could not open an XCB connection for input-region safety.");
-                Disconnect();
+                DisconnectX11();
                 return false;
             }
 
@@ -119,14 +209,18 @@ internal sealed class PlatformInputRegion : IDisposable
         finally
         {
             if (!_ready)
-                Disconnect();
+                DisconnectX11();
         }
     }
 
-    private static XRectangle[] ToXRectangles(IReadOnlyList<Rect> logicalRects, double scaling,
-        int windowWidth, int windowHeight)
+    private static NativeRect[] ToNativeRectangles(IReadOnlyList<Rect> logicalRects, double scaling,
+        Size logicalWindowSize)
     {
-        var result = new List<XRectangle>(logicalRects.Count);
+        scaling = scaling > 0 && double.IsFinite(scaling) ? scaling : 1;
+        var windowWidth = Math.Max(0, (int)Math.Ceiling(logicalWindowSize.Width * scaling));
+        var windowHeight = Math.Max(0, (int)Math.Ceiling(logicalWindowSize.Height * scaling));
+        var result = new List<NativeRect>(logicalRects.Count);
+
         foreach (var rect in logicalRects)
         {
             if (rect.Width <= 0 || rect.Height <= 0 || !double.IsFinite(rect.X) || !double.IsFinite(rect.Y)
@@ -140,25 +234,21 @@ internal sealed class PlatformInputRegion : IDisposable
             if (right <= left || bottom <= top)
                 continue;
 
-            result.Add(new XRectangle
-            {
-                X = (short)Math.Clamp(left, short.MinValue, short.MaxValue),
-                Y = (short)Math.Clamp(top, short.MinValue, short.MaxValue),
-                Width = (ushort)Math.Clamp(right - left, 0, ushort.MaxValue),
-                Height = (ushort)Math.Clamp(bottom - top, 0, ushort.MaxValue)
-            });
+            result.Add(new NativeRect(left, top, right, bottom));
         }
+
         return result.ToArray();
     }
 
     public void Dispose()
     {
         _ready = false;
+        _hwnd = IntPtr.Zero;
         _xid = 0;
-        Disconnect();
+        DisconnectX11();
     }
 
-    private void Disconnect()
+    private void DisconnectX11()
     {
         if (_connection == IntPtr.Zero)
             return;
@@ -171,6 +261,10 @@ internal sealed class PlatformInputRegion : IDisposable
         _connection = IntPtr.Zero;
     }
 
+    private readonly record struct NativeRect(int Left, int Top, int Right, int Bottom);
+
+    private const int RgnOr = 2;
+    private const int ErrorRegion = 0;
     private const byte ShapeSet = 0;
     private const byte ShapeInput = 2;
     private const byte Unsorted = 0;
@@ -206,6 +300,19 @@ internal sealed class PlatformInputRegion : IDisposable
     {
         public readonly uint Sequence;
     }
+
+    [DllImport("user32.dll")]
+    private static extern int SetWindowRgn(IntPtr hWnd, IntPtr hRgn, [MarshalAs(UnmanagedType.Bool)] bool redraw);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateRectRgn(int left, int top, int right, int bottom);
+
+    [DllImport("gdi32.dll")]
+    private static extern int CombineRgn(IntPtr destination, IntPtr source1, IntPtr source2, int combineMode);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteObject(IntPtr objectHandle);
 
     [DllImport("libxcb.so.1", EntryPoint = "xcb_connect")]
     private static extern IntPtr XcbConnect(IntPtr displayName, out int screen);

--- a/src/EdgePilot/Platform/PlatformInputRegion.cs
+++ b/src/EdgePilot/Platform/PlatformInputRegion.cs
@@ -13,8 +13,8 @@ namespace EdgePilot.Platform;
 internal sealed class PlatformInputRegion : IDisposable
 {
     private readonly Window _window;
-    private IntPtr _display;
-    private IntPtr _xid;
+    private IntPtr _connection;
+    private uint _xid;
     private bool _initializationAttempted;
     private bool _ready;
 
@@ -35,17 +35,19 @@ internal sealed class PlatformInputRegion : IDisposable
         var windowHeight = Math.Max(0, (int)Math.Ceiling(logicalWindowSize.Height * scaling));
         var rectangles = ToXRectangles(logicalRects, scaling, windowWidth, windowHeight);
 
-        // XShapeCombineRectangles with one empty rectangle produces an empty ShapeInput
-        // region. Passing a stable array also avoids platform marshalling edge cases for
-        // zero-length arrays.
-        if (rectangles.Length == 0)
-            rectangles = [new XRectangle()];
-
         try
         {
-            XShapeCombineRectangles(_display, _xid, ShapeInput, 0, 0,
-                rectangles, rectangles.Length, ShapeSet, Unsorted);
-            XFlush(_display);
+            // XCB uses a connection independent from Avalonia's own X11 connection. This avoids
+            // introducing Xlib locking/threading into Avalonia's event loop while still applying
+            // SHAPE 1.1's ShapeInput region to the Avalonia-owned XID.
+            _ = XcbShapeRectangles(_connection, ShapeSet, ShapeInput, Unsorted, _xid, 0, 0,
+                (uint)rectangles.Length, rectangles);
+            if (XcbFlush(_connection) <= 0 || XcbConnectionHasError(_connection) != 0)
+            {
+                System.Diagnostics.Trace.WriteLine("EdgePilot lost the X11 connection used for input-region safety.");
+                _ready = false;
+                return false;
+            }
             return true;
         }
         catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
@@ -74,34 +76,50 @@ internal sealed class PlatformInputRegion : IDisposable
                 return false;
             }
 
-            _display = XOpenDisplay(IntPtr.Zero);
-            if (_display == IntPtr.Zero)
+            _connection = XcbConnect(IntPtr.Zero, out _);
+            if (_connection == IntPtr.Zero || XcbConnectionHasError(_connection) != 0)
             {
-                System.Diagnostics.Trace.WriteLine("EdgePilot could not open the X11 display for input-region safety.");
+                System.Diagnostics.Trace.WriteLine("EdgePilot could not open an XCB connection for input-region safety.");
+                Disconnect();
                 return false;
             }
 
-            if (XShapeQueryExtension(_display, out _, out _) == 0)
+            var cookie = XcbShapeQueryVersion(_connection);
+            var reply = XcbShapeQueryVersionReply(_connection, cookie, out var error);
+            try
             {
-                System.Diagnostics.Trace.WriteLine("EdgePilot requires the X Shape extension to constrain the Linux edge input region.");
-                XCloseDisplay(_display);
-                _display = IntPtr.Zero;
-                return false;
+                if (error != IntPtr.Zero || reply == IntPtr.Zero)
+                {
+                    System.Diagnostics.Trace.WriteLine("EdgePilot could not query the X Shape extension.");
+                    return false;
+                }
+
+                var version = Marshal.PtrToStructure<XcbShapeQueryVersionReply>(reply);
+                if (version.MajorVersion < 1 || (version.MajorVersion == 1 && version.MinorVersion < 1))
+                {
+                    System.Diagnostics.Trace.WriteLine($"EdgePilot requires X Shape 1.1 for ShapeInput; server reports {version.MajorVersion}.{version.MinorVersion}.");
+                    return false;
+                }
+            }
+            finally
+            {
+                if (error != IntPtr.Zero) LibcFree(error);
+                if (reply != IntPtr.Zero) LibcFree(reply);
             }
 
-            _xid = handle.Handle;
+            _xid = unchecked((uint)handle.Handle.ToInt64());
             _ready = true;
             return true;
         }
         catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
         {
             System.Diagnostics.Trace.WriteLine($"EdgePilot could not initialize X11 input-region safety: {ex.Message}");
-            if (_display != IntPtr.Zero)
-            {
-                try { XCloseDisplay(_display); } catch { }
-                _display = IntPtr.Zero;
-            }
             return false;
+        }
+        finally
+        {
+            if (!_ready)
+                Disconnect();
         }
     }
 
@@ -136,21 +154,26 @@ internal sealed class PlatformInputRegion : IDisposable
     public void Dispose()
     {
         _ready = false;
-        _xid = IntPtr.Zero;
-        if (_display == IntPtr.Zero)
+        _xid = 0;
+        Disconnect();
+    }
+
+    private void Disconnect()
+    {
+        if (_connection == IntPtr.Zero)
             return;
 
-        try { XCloseDisplay(_display); }
+        try { XcbDisconnect(_connection); }
         catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
         {
             System.Diagnostics.Trace.WriteLine(ex);
         }
-        _display = IntPtr.Zero;
+        _connection = IntPtr.Zero;
     }
 
-    private const int ShapeInput = 2;
-    private const int ShapeSet = 0;
-    private const int Unsorted = 0;
+    private const byte ShapeSet = 0;
+    private const byte ShapeInput = 2;
+    private const byte Unsorted = 0;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct XRectangle
@@ -161,19 +184,53 @@ internal sealed class PlatformInputRegion : IDisposable
         public ushort Height;
     }
 
-    [DllImport("libX11.so.6")]
-    private static extern IntPtr XOpenDisplay(IntPtr displayName);
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly struct XcbShapeQueryVersionCookie
+    {
+        public readonly uint Sequence;
+    }
 
-    [DllImport("libX11.so.6")]
-    private static extern int XCloseDisplay(IntPtr display);
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XcbShapeQueryVersionReply
+    {
+        public byte ResponseType;
+        public byte Pad0;
+        public ushort Sequence;
+        public uint Length;
+        public ushort MajorVersion;
+        public ushort MinorVersion;
+    }
 
-    [DllImport("libX11.so.6")]
-    private static extern int XFlush(IntPtr display);
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly struct XcbVoidCookie
+    {
+        public readonly uint Sequence;
+    }
 
-    [DllImport("libXext.so.6")]
-    private static extern int XShapeQueryExtension(IntPtr display, out int eventBase, out int errorBase);
+    [DllImport("libxcb.so.1", EntryPoint = "xcb_connect")]
+    private static extern IntPtr XcbConnect(IntPtr displayName, out int screen);
 
-    [DllImport("libXext.so.6")]
-    private static extern void XShapeCombineRectangles(IntPtr display, IntPtr destination, int destinationKind,
-        int xOffset, int yOffset, [In] XRectangle[] rectangles, int rectangleCount, int operation, int ordering);
+    [DllImport("libxcb.so.1", EntryPoint = "xcb_connection_has_error")]
+    private static extern int XcbConnectionHasError(IntPtr connection);
+
+    [DllImport("libxcb.so.1", EntryPoint = "xcb_flush")]
+    private static extern int XcbFlush(IntPtr connection);
+
+    [DllImport("libxcb.so.1", EntryPoint = "xcb_disconnect")]
+    private static extern void XcbDisconnect(IntPtr connection);
+
+    [DllImport("libxcb-shape.so.0", EntryPoint = "xcb_shape_query_version")]
+    private static extern XcbShapeQueryVersionCookie XcbShapeQueryVersion(IntPtr connection);
+
+    [DllImport("libxcb-shape.so.0", EntryPoint = "xcb_shape_query_version_reply")]
+    private static extern IntPtr XcbShapeQueryVersionReply(IntPtr connection,
+        XcbShapeQueryVersionCookie cookie, out IntPtr error);
+
+    [DllImport("libxcb-shape.so.0", EntryPoint = "xcb_shape_rectangles")]
+    private static extern XcbVoidCookie XcbShapeRectangles(IntPtr connection, byte operation,
+        byte destinationKind, byte ordering, uint destinationWindow, short xOffset, short yOffset,
+        uint rectanglesLength, [In] XRectangle[] rectangles);
+
+    [DllImport("libc.so.6", EntryPoint = "free")]
+    private static extern void LibcFree(IntPtr pointer);
 }

--- a/src/EdgePilot/Platform/PlatformInputRegion.cs
+++ b/src/EdgePilot/Platform/PlatformInputRegion.cs
@@ -19,6 +19,7 @@ internal sealed class PlatformInputRegion : IDisposable
     private uint _xid;
     private bool _windowsInitializationAttempted;
     private bool _x11InitializationAttempted;
+    private bool _windowsRegionVerified;
     private bool _ready;
     private int? _lastNativeRegionHash;
 
@@ -65,6 +66,11 @@ internal sealed class PlatformInputRegion : IDisposable
                 return FailWindows("EdgePilot could not apply the Windows input-safe window region.");
 
             region = IntPtr.Zero;
+
+            if (!_windowsRegionVerified && !VerifyWindowsRegion(rectangles))
+                return FailWindows("EdgePilot could not verify the applied Windows window region.");
+
+            _windowsRegionVerified = true;
             _ready = true;
             return true;
         }
@@ -76,6 +82,30 @@ internal sealed class PlatformInputRegion : IDisposable
         {
             if (region != IntPtr.Zero)
                 DeleteObject(region);
+        }
+    }
+
+    private bool VerifyWindowsRegion(NativeRect[] rectangles)
+    {
+        var expected = CreateWindowsRegion(rectangles);
+        var actual = CreateRectRgn(0, 0, 0, 0);
+        if (expected == IntPtr.Zero || actual == IntPtr.Zero)
+        {
+            if (expected != IntPtr.Zero) DeleteObject(expected);
+            if (actual != IntPtr.Zero) DeleteObject(actual);
+            return false;
+        }
+
+        try
+        {
+            if (GetWindowRgn(_hwnd, actual) == RegionError)
+                return false;
+            return EqualRgn(expected, actual);
+        }
+        finally
+        {
+            DeleteObject(expected);
+            DeleteObject(actual);
         }
     }
 
@@ -163,12 +193,22 @@ internal sealed class PlatformInputRegion : IDisposable
 
         try
         {
-            // XCB uses a connection independent from Avalonia's own X11 connection. This avoids
-            // introducing Xlib locking/threading into Avalonia's event loop while still applying
-            // SHAPE 1.1's ShapeInput region to the Avalonia-owned XID.
-            _ = XcbShapeRectangles(_connection, ShapeSet, ShapeInput, Unsorted, _xid, 0, 0,
-                (uint)rectangles.Length, rectangles);
-            if (XcbFlush(_connection) <= 0 || XcbConnectionHasError(_connection) != 0)
+            // XCB uses a connection independent from Avalonia's own X11 connection. A checked
+            // SHAPE request lets the package smoke test prove that the server accepted ShapeInput,
+            // not merely that the request could be queued locally.
+            var cookie = XcbShapeRectanglesChecked(_connection, ShapeSet, ShapeInput, Unsorted,
+                _xid, 0, 0, (uint)rectangles.Length, rectangles);
+            var error = XcbRequestCheck(_connection, cookie);
+            if (error != IntPtr.Zero)
+            {
+                LibcFree(error);
+                System.Diagnostics.Trace.WriteLine("The X server rejected EdgePilot's ShapeInput region.");
+                _ready = false;
+                _lastNativeRegionHash = null;
+                return false;
+            }
+
+            if (XcbConnectionHasError(_connection) != 0)
             {
                 System.Diagnostics.Trace.WriteLine("EdgePilot lost the X11 connection used for input-region safety.");
                 _ready = false;
@@ -265,21 +305,24 @@ internal sealed class PlatformInputRegion : IDisposable
                 || !double.IsFinite(rect.Width) || !double.IsFinite(rect.Height))
                 continue;
 
-            var left = Math.Clamp((int)Math.Ceiling(rect.Left * scaling), 0, windowWidth);
-            var top = Math.Clamp((int)Math.Ceiling(rect.Top * scaling), 0, windowHeight);
-            var right = Math.Clamp((int)Math.Floor(rect.Right * scaling), 0, windowWidth);
-            var bottom = Math.Clamp((int)Math.Floor(rect.Bottom * scaling), 0, windowHeight);
+            // Region coordinates are integral device pixels. Nearest-pixel quantization keeps
+            // adjacent one-DIP scanlines sharing the exact same boundary at fractional DPI, so
+            // SetWindowRgn cannot cut visible one-pixel seams through the animated notch.
+            var left = Quantize(rect.Left * scaling, windowWidth);
+            var top = Quantize(rect.Top * scaling, windowHeight);
+            var right = Quantize(rect.Right * scaling, windowWidth);
+            var bottom = Quantize(rect.Bottom * scaling, windowHeight);
             if (right <= left || bottom <= top)
                 continue;
 
-            // Inset rounding is deliberate. The native region must never grow beyond the logical
-            // live area because a one-pixel missed EdgePilot fringe is safer than stealing a click
-            // from the application underneath.
             result.Add(new NativeRect(left, top, right, bottom));
         }
 
         return result.ToArray();
     }
+
+    private static int Quantize(double value, int maximum) =>
+        Math.Clamp((int)Math.Round(value, MidpointRounding.AwayFromZero), 0, maximum);
 
     private static int HashNativeRectangles(NativeRect[] rectangles)
     {
@@ -298,6 +341,7 @@ internal sealed class PlatformInputRegion : IDisposable
     public void Dispose()
     {
         _ready = false;
+        _windowsRegionVerified = false;
         _lastNativeRegionHash = null;
         _hwnd = IntPtr.Zero;
         _xid = 0;
@@ -345,6 +389,7 @@ internal sealed class PlatformInputRegion : IDisposable
     }
 
     private const uint RectanglesRegionType = 1;
+    private const int RegionError = 0;
     private const byte ShapeSet = 0;
     private const byte ShapeInput = 2;
     private const byte Unsorted = 0;
@@ -384,11 +429,18 @@ internal sealed class PlatformInputRegion : IDisposable
     [DllImport("user32.dll")]
     private static extern int SetWindowRgn(IntPtr hWnd, IntPtr hRgn, [MarshalAs(UnmanagedType.Bool)] bool redraw);
 
+    [DllImport("user32.dll")]
+    private static extern int GetWindowRgn(IntPtr hWnd, IntPtr hRgn);
+
     [DllImport("gdi32.dll")]
     private static extern IntPtr CreateRectRgn(int left, int top, int right, int bottom);
 
     [DllImport("gdi32.dll")]
     private static extern IntPtr ExtCreateRegion(IntPtr transform, uint dataSize, IntPtr regionData);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EqualRgn(IntPtr first, IntPtr second);
 
     [DllImport("gdi32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
@@ -400,8 +452,8 @@ internal sealed class PlatformInputRegion : IDisposable
     [DllImport("libxcb.so.1", EntryPoint = "xcb_connection_has_error")]
     private static extern int XcbConnectionHasError(IntPtr connection);
 
-    [DllImport("libxcb.so.1", EntryPoint = "xcb_flush")]
-    private static extern int XcbFlush(IntPtr connection);
+    [DllImport("libxcb.so.1", EntryPoint = "xcb_request_check")]
+    private static extern IntPtr XcbRequestCheck(IntPtr connection, XcbVoidCookie cookie);
 
     [DllImport("libxcb.so.1", EntryPoint = "xcb_disconnect")]
     private static extern void XcbDisconnect(IntPtr connection);
@@ -413,8 +465,8 @@ internal sealed class PlatformInputRegion : IDisposable
     private static extern IntPtr XcbShapeQueryVersionReply(IntPtr connection,
         XcbShapeQueryVersionCookie cookie, out IntPtr error);
 
-    [DllImport("libxcb-shape.so.0", EntryPoint = "xcb_shape_rectangles")]
-    private static extern XcbVoidCookie XcbShapeRectangles(IntPtr connection, byte operation,
+    [DllImport("libxcb-shape.so.0", EntryPoint = "xcb_shape_rectangles_checked")]
+    private static extern XcbVoidCookie XcbShapeRectanglesChecked(IntPtr connection, byte operation,
         byte destinationKind, byte ordering, uint destinationWindow, short xOffset, short yOffset,
         uint rectanglesLength, [In] XRectangle[] rectangles);
 

--- a/src/EdgePilot/Platform/SingleInstance.cs
+++ b/src/EdgePilot/Platform/SingleInstance.cs
@@ -19,7 +19,8 @@ internal sealed class SingleInstance : IDisposable
     {
         var user = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         _name = "EdgePilot-" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(user)))[..20];
-        _mutex = new Mutex(false, _name);
+        var options = new NamedWaitHandleOptions { CurrentUserOnly = true, CurrentSessionOnly = false };
+        _mutex = new Mutex(false, _name, options);
         try { _ownsMutex = _mutex.WaitOne(0); }
         catch (AbandonedMutexException) { _ownsMutex = true; }
         if (_ownsMutex) _ = ListenAsync(_stop.Token);

--- a/src/EdgePilot/UI/EdgeNotchGeometry.cs
+++ b/src/EdgePilot/UI/EdgeNotchGeometry.cs
@@ -5,7 +5,7 @@ namespace EdgePilot.UI;
 
 internal static class EdgeNotchGeometry
 {
-    private const double InputStripHeight = 2;
+    private const double InputStripHeight = 1;
 
     public static Geometry BuildRight(double windowWidth, double windowHeight, double depth, double length)
     {
@@ -70,16 +70,16 @@ internal static class EdgeNotchGeometry
     }
 
     /// <summary>
-    /// Returns a conservative union of thin rectangles that lies inside the visible notch.
-    /// Native window/input regions are rectangular, so this scanline representation prevents
-    /// the transparent corners and concave shoulders of the notch's bounding box from becoming
+    /// Returns a conservative union of one-DIP scanline rectangles that lies inside the visible
+    /// notch. Native window/input regions are rectangular, so this representation prevents the
+    /// transparent corners and concave shoulders of the notch's bounding box from becoming
     /// invisible click blockers. The intentional Hover hot-zone is added separately by EdgeWindow.
     /// </summary>
     public static Rect[] BuildInputStripsRight(double windowWidth, double windowHeight,
         double depth, double length)
     {
         var shape = Calculate(windowWidth, windowHeight, depth, length);
-        var result = new List<Rect>((int)Math.Ceiling((shape.Bottom - shape.Top) / InputStripHeight));
+        var result = new List<Rect>((int)Math.Ceiling(shape.Bottom - shape.Top));
 
         for (var y = shape.Top; y < shape.Bottom - 0.001; y += InputStripHeight)
         {

--- a/src/EdgePilot/UI/EdgeNotchGeometry.cs
+++ b/src/EdgePilot/UI/EdgeNotchGeometry.cs
@@ -5,7 +5,134 @@ namespace EdgePilot.UI;
 
 internal static class EdgeNotchGeometry
 {
+    private const double InputStripHeight = 2;
+
     public static Geometry BuildRight(double windowWidth, double windowHeight, double depth, double length)
+    {
+        var shape = Calculate(windowWidth, windowHeight, depth, length);
+        var geometry = new StreamGeometry();
+        using var ctx = geometry.Open();
+        ctx.BeginFigure(new Point(shape.Right, shape.Top), true);
+
+        if (shape.Flare > 0.1)
+        {
+            ctx.ArcTo(
+                new Point(shape.Right - shape.Flare, shape.BodyTop),
+                new Size(shape.Flare, shape.Flare),
+                0,
+                false,
+                SweepDirection.Clockwise,
+                true);
+        }
+
+        ctx.LineTo(new Point(shape.Left + shape.Corner, shape.BodyTop), true);
+
+        if (shape.Corner > 0.1)
+        {
+            ctx.ArcTo(
+                new Point(shape.Left, shape.BodyTop + shape.Corner),
+                new Size(shape.Corner, shape.Corner),
+                0,
+                false,
+                SweepDirection.CounterClockwise,
+                true);
+        }
+
+        ctx.LineTo(new Point(shape.Left, shape.BodyBottom - shape.Corner), true);
+
+        if (shape.Corner > 0.1)
+        {
+            ctx.ArcTo(
+                new Point(shape.Left + shape.Corner, shape.BodyBottom),
+                new Size(shape.Corner, shape.Corner),
+                0,
+                false,
+                SweepDirection.CounterClockwise,
+                true);
+        }
+
+        ctx.LineTo(new Point(shape.Right - shape.Flare, shape.BodyBottom), true);
+
+        if (shape.Flare > 0.1)
+        {
+            ctx.ArcTo(
+                new Point(shape.Right, shape.Bottom),
+                new Size(shape.Flare, shape.Flare),
+                0,
+                false,
+                SweepDirection.Clockwise,
+                true);
+        }
+
+        ctx.LineTo(new Point(shape.Right, shape.Top), true);
+        ctx.EndFigure(true);
+        return geometry;
+    }
+
+    /// <summary>
+    /// Returns a conservative union of thin rectangles that lies inside the visible notch.
+    /// Native window/input regions are rectangular, so this scanline representation prevents
+    /// the transparent corners and concave shoulders of the notch's bounding box from becoming
+    /// invisible click blockers. The intentional Hover hot-zone is added separately by EdgeWindow.
+    /// </summary>
+    public static Rect[] BuildInputStripsRight(double windowWidth, double windowHeight,
+        double depth, double length)
+    {
+        var shape = Calculate(windowWidth, windowHeight, depth, length);
+        var result = new List<Rect>((int)Math.Ceiling((shape.Bottom - shape.Top) / InputStripHeight));
+
+        for (var y = shape.Top; y < shape.Bottom - 0.001; y += InputStripHeight)
+        {
+            var bottom = Math.Min(shape.Bottom, y + InputStripHeight);
+            // The left contour is monotonic toward the center and then monotonic away from it.
+            // Taking the larger endpoint therefore under-approximates the curved silhouette for
+            // the whole strip instead of accidentally claiming transparent pixels as input.
+            var left = Math.Max(LeftAt(shape, y), LeftAt(shape, bottom));
+            if (shape.Right - left > 0.01 && bottom - y > 0.01)
+                result.Add(new Rect(left, y, shape.Right - left, bottom - y));
+        }
+
+        return result.ToArray();
+    }
+
+    private static double LeftAt(NotchShape shape, double y)
+    {
+        y = Math.Clamp(y, shape.Top, shape.Bottom);
+
+        if (shape.Flare > 0.1 && y < shape.BodyTop)
+        {
+            var dy = y - shape.Top;
+            return shape.Right - shape.Flare +
+                   Math.Sqrt(Math.Max(0, shape.Flare * shape.Flare - dy * dy));
+        }
+
+        if (shape.Corner > 0.1 && y < shape.BodyTop + shape.Corner)
+        {
+            var centerY = shape.BodyTop + shape.Corner;
+            var dy = y - centerY;
+            return shape.Left + shape.Corner -
+                   Math.Sqrt(Math.Max(0, shape.Corner * shape.Corner - dy * dy));
+        }
+
+        if (shape.Corner > 0.1 && y > shape.BodyBottom - shape.Corner)
+        {
+            var centerY = shape.BodyBottom - shape.Corner;
+            var dy = y - centerY;
+            return shape.Left + shape.Corner -
+                   Math.Sqrt(Math.Max(0, shape.Corner * shape.Corner - dy * dy));
+        }
+
+        if (shape.Flare > 0.1 && y > shape.BodyBottom)
+        {
+            var dy = y - shape.Bottom;
+            return shape.Right - shape.Flare +
+                   Math.Sqrt(Math.Max(0, shape.Flare * shape.Flare - dy * dy));
+        }
+
+        return shape.Left;
+    }
+
+    private static NotchShape Calculate(double windowWidth, double windowHeight, double depth, double length)
     {
         depth = Math.Max(1, depth);
         length = Math.Max(8, Math.Min(length, windowHeight));
@@ -25,65 +152,10 @@ internal static class EdgeNotchGeometry
             Math.Min(length / 4, Math.Max(0, depth - corner)));
         corner = Math.Min(corner, Math.Max(0, (length - flare * 2) / 2));
 
-        var bodyTop = top + flare;
-        var bodyBottom = bottom - flare;
-
-        var geometry = new StreamGeometry();
-        using var ctx = geometry.Open();
-        ctx.BeginFigure(new Point(right, top), true);
-
-        if (flare > 0.1)
-        {
-            ctx.ArcTo(
-                new Point(right - flare, bodyTop),
-                new Size(flare, flare),
-                0,
-                false,
-                SweepDirection.Clockwise,
-                true);
-        }
-
-        ctx.LineTo(new Point(left + corner, bodyTop), true);
-
-        if (corner > 0.1)
-        {
-            ctx.ArcTo(
-                new Point(left, bodyTop + corner),
-                new Size(corner, corner),
-                0,
-                false,
-                SweepDirection.CounterClockwise,
-                true);
-        }
-
-        ctx.LineTo(new Point(left, bodyBottom - corner), true);
-
-        if (corner > 0.1)
-        {
-            ctx.ArcTo(
-                new Point(left + corner, bodyBottom),
-                new Size(corner, corner),
-                0,
-                false,
-                SweepDirection.CounterClockwise,
-                true);
-        }
-
-        ctx.LineTo(new Point(right - flare, bodyBottom), true);
-
-        if (flare > 0.1)
-        {
-            ctx.ArcTo(
-                new Point(right, bottom),
-                new Size(flare, flare),
-                0,
-                false,
-                SweepDirection.Clockwise,
-                true);
-        }
-
-        ctx.LineTo(new Point(right, top), true);
-        ctx.EndFigure(true);
-        return geometry;
+        return new NotchShape(top, bottom, right, left, corner, flare,
+            top + flare, bottom - flare);
     }
+
+    private readonly record struct NotchShape(double Top, double Bottom, double Right, double Left,
+        double Corner, double Flare, double BodyTop, double BodyBottom);
 }

--- a/src/EdgePilot/UI/EdgeWindow.cs
+++ b/src/EdgePilot/UI/EdgeWindow.cs
@@ -73,7 +73,6 @@ public sealed class EdgeWindow : Window
     private SettingsWindow? _settingsWindow;
     private int? _hoveredMetric;
 
-    private readonly Win32Properties.CustomWndProcHookCallback? _wndProcHook;
     private readonly PlatformInputRegion _inputRegion;
 
     public EdgeWindow()
@@ -208,15 +207,10 @@ public sealed class EdgeWindow : Window
             Interval = TimeSpan.FromMilliseconds(40)
         };
         _cursorTimer.Tick += (_, _) => PollCursor();
-
-        if (OperatingSystem.IsWindows())
-        {
-            _wndProcHook = WndProc;
-            Win32Properties.AddWndProcHookCallback(this, _wndProcHook);
-        }
     }
 
-    internal bool HasSafePlatformInput => !OperatingSystem.IsLinux() || _inputRegion.IsReady;
+    internal bool HasSafePlatformInput =>
+        (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux()) || _inputRegion.IsReady;
 
     private void OnOpened(object? sender, EventArgs e)
     {
@@ -247,9 +241,6 @@ public sealed class EdgeWindow : Window
         if (_screensSubscribed) Screens.Changed -= OnScreensChanged;
         _monitor.SnapshotUpdated -= OnSnapshotUpdated;
         _monitor.CaptureFailed -= OnCaptureFailed;
-
-        if (_wndProcHook is not null)
-            Win32Properties.RemoveWndProcHookCallback(this, _wndProcHook);
 
         _inputRegion.Dispose();
         _lifetime.Dispose();
@@ -312,7 +303,7 @@ public sealed class EdgeWindow : Window
         if (!_expanded)
         {
             if (HotZoneRect().Contains(point) ||
-                (_expansion > 0.05 && ShapeRect().Contains(point)))
+                (_expansion > 0.05 && ShapeContains(point)))
                 Expand();
             return;
         }
@@ -321,15 +312,16 @@ public sealed class EdgeWindow : Window
         if (hovered is not null)
             SetHoveredMetric(hovered);
         else if (!TooltipLiveRect().Contains(point) && !BridgeRect().Contains(point)
-                 && !ExpandedLiveRect().Contains(point))
+                 && !ShapeContains(point))
             SetHoveredMetric(null);
 
-        if (ExpandedLiveRect().Contains(point) || HotZoneRect().Contains(point)
+        if (ShapeContains(point) || HotZoneRect().Contains(point)
             || TooltipLiveRect().Contains(point) || BridgeRect().Contains(point))
             CancelFold();
         else
             ScheduleFold();
     }
+
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
@@ -343,7 +335,7 @@ public sealed class EdgeWindow : Window
             return;
 
         var point = e.GetPosition(this);
-        if (!ShapeRect().Contains(point))
+        if (!ShapeContains(point))
             return;
 
         if (!_expanded)
@@ -379,6 +371,7 @@ public sealed class EdgeWindow : Window
         _motionClock.Restart();
         _motionTimer.Start();
     }
+
     private void UpdateNotchVisual()
     {
         var p = Math.Clamp(_expansion, 0, 1.025);
@@ -659,7 +652,17 @@ public sealed class EdgeWindow : Window
         return NotchLayout.ToScreen(new Rect(WindowWidth - depth, (WindowHeight - length) / 2, depth, length), _edge);
     }
 
-    private Rect ExpandedLiveRect() => ShapeRect();
+    private Rect[] ShapeInputRects()
+    {
+        var p = Math.Clamp(_expansion, 0, 1.025);
+        var depth = Lerp(CollapsedDepth, ExpandedDepth, p);
+        var length = Lerp(CollapsedLength, ExpandedLength, p);
+        return EdgeNotchGeometry.BuildInputStripsRight(WindowWidth, WindowHeight, depth, length)
+            .Select(rect => NotchLayout.ToScreen(rect, _edge))
+            .ToArray();
+    }
+
+    private bool ShapeContains(Point point) => ShapeInputRects().Any(rect => rect.Contains(point));
 
     private Rect TooltipLiveRect()
     {
@@ -692,11 +695,12 @@ public sealed class EdgeWindow : Window
         if (_mode == NotchDisplayMode.Hidden)
             return [];
 
-        var regions = new List<Rect>(4);
+        var shape = ShapeInputRects();
+        var regions = new List<Rect>(shape.Length + 3);
         if (_mode == NotchDisplayMode.Hover)
             regions.Add(HotZoneRect());
 
-        regions.Add(ShapeRect());
+        regions.AddRange(shape);
 
         var tooltip = TooltipLiveRect();
         if (tooltip.Width > 0 && tooltip.Height > 0)
@@ -713,15 +717,15 @@ public sealed class EdgeWindow : Window
 
     private bool UpdatePlatformInputRegion()
     {
-        if (!OperatingSystem.IsLinux() || !_started || !IsVisible)
+        if ((!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux()) || !_started || !IsVisible)
             return true;
 
         if (_inputRegion.TryApply(InteractiveRects(), RenderScaling, new Size(Width, Height)))
             return true;
 
         // Failing closed is intentional: a hidden edge surface is preferable to leaving a
-        // large transparent topmost rectangle that blocks the user's desktop.
-        System.Diagnostics.Trace.WriteLine("EdgePilot disabled the Linux edge surface because a safe native input region could not be established.");
+        // transparent topmost rectangle that blocks the user's desktop or another application.
+        System.Diagnostics.Trace.WriteLine("EdgePilot disabled the edge surface because a safe native input region could not be established.");
         _cursorTimer.Stop();
         Hide();
         return false;
@@ -740,24 +744,6 @@ public sealed class EdgeWindow : Window
 
         point = default;
         return false;
-    }
-
-    private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, ref bool handled)
-    {
-        const uint WmNcHitTest = 0x0084;
-        const int HtTransparent = -1;
-        const int HtClient = 1;
-
-        if (msg != WmNcHitTest || !GetCursorPos(out var cursor))
-            return IntPtr.Zero;
-
-        var scaling = RenderScaling <= 0 ? 1 : RenderScaling;
-        var point = new Point(
-            (cursor.X - Position.X) / scaling,
-            (cursor.Y - Position.Y) / scaling);
-
-        handled = true;
-        return new IntPtr(IsInteractive(point) ? HtClient : HtTransparent);
     }
 
     private void Relocate()

--- a/src/EdgePilot/UI/EdgeWindow.cs
+++ b/src/EdgePilot/UI/EdgeWindow.cs
@@ -74,6 +74,7 @@ public sealed class EdgeWindow : Window
     private int? _hoveredMetric;
 
     private readonly Win32Properties.CustomWndProcHookCallback? _wndProcHook;
+    private readonly PlatformInputRegion _inputRegion;
 
     public EdgeWindow()
     {
@@ -89,6 +90,8 @@ public sealed class EdgeWindow : Window
         Background = Brushes.Transparent;
         TransparencyBackgroundFallback = Brushes.Transparent;
         TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
+
+        _inputRegion = new PlatformInputRegion(this);
 
         _notchShape = new Path
         {
@@ -194,7 +197,11 @@ public sealed class EdgeWindow : Window
 
         Opened += OnOpened;
         Closed += OnClosed;
-        ScalingChanged += (_, _) => Relocate();
+        ScalingChanged += (_, _) =>
+        {
+            Relocate();
+            UpdatePlatformInputRegion();
+        };
 
         _cursorTimer = new DispatcherTimer
         {
@@ -209,6 +216,8 @@ public sealed class EdgeWindow : Window
         }
     }
 
+    internal bool HasSafePlatformInput => !OperatingSystem.IsLinux() || _inputRegion.IsReady;
+
     private void OnOpened(object? sender, EventArgs e)
     {
         Relocate();
@@ -216,9 +225,16 @@ public sealed class EdgeWindow : Window
         _started = true;
         Screens.Changed += OnScreensChanged;
         _screensSubscribed = true;
-        _cursorTimer.Start();
         _ = Task.Run(() => _monitor.RunAsync(_lifetime.Token));
-        if (_mode == NotchDisplayMode.Hidden) { _cursorTimer.Stop(); Hide(); }
+        if (_mode == NotchDisplayMode.Hidden)
+        {
+            _cursorTimer.Stop();
+            Hide();
+        }
+        else if (UpdatePlatformInputRegion())
+        {
+            _cursorTimer.Start();
+        }
     }
 
     private void OnClosed(object? sender, EventArgs e)
@@ -235,8 +251,7 @@ public sealed class EdgeWindow : Window
         if (_wndProcHook is not null)
             Win32Properties.RemoveWndProcHookCallback(this, _wndProcHook);
 
-
-
+        _inputRegion.Dispose();
         _lifetime.Dispose();
     }
 
@@ -278,6 +293,7 @@ public sealed class EdgeWindow : Window
         {
             RenderTooltip(_hoveredMetric.Value);
             PositionTooltip(_hoveredMetric.Value);
+            UpdatePlatformInputRegion();
         }
     }
 
@@ -346,6 +362,7 @@ public sealed class EdgeWindow : Window
         if (_expanded) return;
         _expanded = true;
         StartMotion(1);
+        UpdatePlatformInputRegion();
     }
 
     private void ScheduleFold()
@@ -388,6 +405,8 @@ public sealed class EdgeWindow : Window
             _tooltipCard.IsVisible = true;
             _tooltipCard.Opacity = Math.Clamp((p - 0.78) / 0.22, 0, 1);
         }
+
+        UpdatePlatformInputRegion();
     }
 
     private int? MetricIndexAt(Point point)
@@ -424,6 +443,7 @@ public sealed class EdgeWindow : Window
         {
             _tooltipCard.Opacity = 0;
             _tooltipCard.IsVisible = false;
+            UpdatePlatformInputRegion();
             return;
         }
 
@@ -431,6 +451,7 @@ public sealed class EdgeWindow : Window
         PositionTooltip(index.Value);
         _tooltipCard.IsVisible = true;
         _tooltipCard.Opacity = 1;
+        UpdatePlatformInputRegion();
     }
 
     private void RenderTooltip(int index)
@@ -536,7 +557,8 @@ public sealed class EdgeWindow : Window
             else
             {
                 Show();
-                _cursorTimer.Start();
+                if (UpdatePlatformInputRegion()) _cursorTimer.Start();
+                else _cursorTimer.Stop();
             }
         }
         if (_latestSnapshot is not null) RenderSnapshot(_latestSnapshot);
@@ -665,15 +687,44 @@ public sealed class EdgeWindow : Window
         };
     }
 
-    private bool IsInteractive(Point point)
+    private Rect[] InteractiveRects()
     {
-        if (_mode == NotchDisplayMode.Hidden) return false;
-        if (!_expanded)
-            return HotZoneRect().Contains(point) || ShapeRect().Contains(point);
+        if (_mode == NotchDisplayMode.Hidden)
+            return [];
 
-        return ExpandedLiveRect().Contains(point)
-            || TooltipLiveRect().Contains(point)
-            || BridgeRect().Contains(point);
+        var regions = new List<Rect>(4);
+        if (_mode == NotchDisplayMode.Hover)
+            regions.Add(HotZoneRect());
+
+        regions.Add(ShapeRect());
+
+        var tooltip = TooltipLiveRect();
+        if (tooltip.Width > 0 && tooltip.Height > 0)
+            regions.Add(tooltip);
+
+        var bridge = BridgeRect();
+        if (bridge.Width > 0 && bridge.Height > 0)
+            regions.Add(bridge);
+
+        return regions.ToArray();
+    }
+
+    private bool IsInteractive(Point point) => InteractiveRects().Any(rect => rect.Contains(point));
+
+    private bool UpdatePlatformInputRegion()
+    {
+        if (!OperatingSystem.IsLinux() || !_started || !IsVisible)
+            return true;
+
+        if (_inputRegion.TryApply(InteractiveRects(), RenderScaling, new Size(Width, Height)))
+            return true;
+
+        // Failing closed is intentional: a hidden edge surface is preferable to leaving a
+        // large transparent topmost rectangle that blocks the user's desktop.
+        System.Diagnostics.Trace.WriteLine("EdgePilot disabled the Linux edge surface because a safe native input region could not be established.");
+        _cursorTimer.Stop();
+        Hide();
+        return false;
     }
 
     private bool TryGetCursorLocal(out Point point)

--- a/tests/EdgePilot.InputChecks/EdgePilot.InputChecks.csproj
+++ b/tests/EdgePilot.InputChecks/EdgePilot.InputChecks.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/EdgePilot/EdgePilot.csproj" />
+    <PackageReference Include="Avalonia.Headless" Version="12.1.2" />
+  </ItemGroup>
+</Project>

--- a/tests/EdgePilot.InputChecks/Program.cs
+++ b/tests/EdgePilot.InputChecks/Program.cs
@@ -112,4 +112,26 @@ foreach (var edge in Enum.GetValues<EdgeSide>())
         $"transparent notch shoulder passes through on {edge}");
 }
 
+// Native regions use integral device pixels. Verify that two adjacent logical scanlines remain
+// adjacent after fractional-DPI quantization instead of creating a one-pixel hole between them.
+var platformType = typeof(EdgeWindow).Assembly.GetType("EdgePilot.Platform.PlatformInputRegion")!;
+var toNative = platformType.GetMethod("ToNativeRectangles", BindingFlags.Static | BindingFlags.NonPublic)!;
+var nativeArray = (Array)toNative.Invoke(null, new object[]
+{
+    new[]
+    {
+        new Rect(100.2, 50.1, 20.4, 1.0),
+        new Rect(100.2, 51.1, 20.4, 1.0)
+    },
+    1.25d,
+    new Size(NotchLayout.DesignWidth, NotchLayout.DesignHeight)
+})!;
+Check(nativeArray.Length == 2, "fractional-DPI scanlines survive native quantization");
+var nativeType = nativeArray.GetType().GetElementType()!;
+var first = nativeArray.GetValue(0)!;
+var second = nativeArray.GetValue(1)!;
+var bottom = (int)nativeType.GetField("Bottom", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(first)!;
+var top = (int)nativeType.GetField("Top", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(second)!;
+Check(bottom == top, "fractional-DPI scanlines share a native pixel boundary");
+
 Console.WriteLine($"{passed} input-region checks passed.");

--- a/tests/EdgePilot.InputChecks/Program.cs
+++ b/tests/EdgePilot.InputChecks/Program.cs
@@ -27,6 +27,7 @@ void Set(EdgeWindow window, string name, object value) =>
     typeof(EdgeWindow).GetField(name, Flags)!.SetValue(window, value);
 
 Rect[] Regions(EdgeWindow window) => (Rect[])Call(window, "InteractiveRects")!;
+Rect[] ShapeRegions(EdgeWindow window) => (Rect[])Call(window, "ShapeInputRects")!;
 bool Interactive(EdgeWindow window, Point point) => (bool)Call(window, "IsInteractive", point)!;
 
 var window = new EdgeWindow();
@@ -44,22 +45,28 @@ foreach (var edge in Enum.GetValues<EdgeSide>())
     Set(window, "_expansion", 0d);
     Call(window, "UpdateNotchVisual");
 
+    var collapsedShape = ShapeRegions(window);
     var collapsed = Regions(window);
     var hot = (Rect)Call(window, "HotZoneRect")!;
-    var shape = (Rect)Call(window, "ShapeRect")!;
-    Check(collapsed.Length == 2, $"hover collapsed exposes only hot-zone and shape on {edge}");
+    var shapeBounds = (Rect)Call(window, "ShapeRect")!;
+    Check(collapsedShape.Length > 1, $"collapsed notch is represented by silhouette strips on {edge}");
+    Check(collapsed.Length == collapsedShape.Length + 1,
+        $"hover collapsed exposes only hot-zone and silhouette on {edge}");
     Check(collapsed.All(windowRect.Contains), $"collapsed regions stay inside window on {edge}");
     Check(collapsed.All(r => r.Width * r.Height < size.Width * size.Height),
         $"collapsed regions never become the full transparent window on {edge}");
     Check(Interactive(window, hot.Center), $"hover hot-zone remains interactive on {edge}");
-    Check(Interactive(window, shape.Center), $"collapsed notch remains interactive on {edge}");
+    Check(Interactive(window, shapeBounds.Center), $"collapsed notch remains interactive on {edge}");
     Check(!Interactive(window, windowRect.Center), $"transparent window center passes through on {edge}");
 
     Set(window, "_expanded", true);
     Set(window, "_expansion", 1d);
     Call(window, "UpdateNotchVisual");
+    var expandedShape = ShapeRegions(window);
     var expanded = Regions(window);
-    Check(expanded.Length == 2, $"expanded hover keeps hot-zone and notch only on {edge}");
+    Check(expandedShape.Length > collapsedShape.Length, $"expanded silhouette grows with the notch on {edge}");
+    Check(expanded.Length == expandedShape.Length + 1,
+        $"expanded hover keeps hot-zone and silhouette only on {edge}");
     Check(expanded.All(windowRect.Contains), $"expanded regions stay inside window on {edge}");
     Check(!Interactive(window, windowRect.Center), $"expanded transparent area passes through on {edge}");
 
@@ -67,7 +74,8 @@ foreach (var edge in Enum.GetValues<EdgeSide>())
     var withTooltip = Regions(window);
     var tooltip = (Rect)Call(window, "TooltipLiveRect")!;
     var bridge = (Rect)Call(window, "BridgeRect")!;
-    Check(withTooltip.Length == 4, $"tooltip adds only card and bridge on {edge}");
+    Check(withTooltip.Length == expandedShape.Length + 3,
+        $"tooltip adds only card and bridge to live regions on {edge}");
     Check(tooltip.Width > 0 && tooltip.Height > 0 && Interactive(window, tooltip.Center),
         $"tooltip stays interactive on {edge}");
     Check(bridge.Width > 0 && bridge.Height > 0 && Interactive(window, bridge.Center),
@@ -82,10 +90,26 @@ foreach (var edge in Enum.GetValues<EdgeSide>())
     Set(window, "_expanded", true);
     Set(window, "_expansion", 1d);
     Call(window, "UpdateNotchVisual");
+    var alwaysShape = ShapeRegions(window);
     var always = Regions(window);
-    Check(always.Length == 1, $"always mode exposes only the current notch without tooltip on {edge}");
+    Check(always.Length == alwaysShape.Length,
+        $"always mode exposes only the exact current notch without tooltip on {edge}");
     Check(always.All(windowRect.Contains), $"always region stays inside window on {edge}");
     Check(!Interactive(window, windowRect.Center), $"always mode transparent area passes through on {edge}");
+
+    // This point is inside the rectangular bounds used by the old hit testing, but outside the
+    // visible expanded notch shoulder. It must never become an invisible input blocker.
+    const double expandedDepth = 88;
+    const double expandedLength = 408; // 4*78 + 3*10 + 66 with all metrics visible.
+    var transparentShoulderDesign = new Point(
+        NotchLayout.DesignWidth - expandedDepth + 1,
+        (NotchLayout.DesignHeight - expandedLength) / 2 + 1);
+    var transparentShoulder = NotchLayout.ToScreen(transparentShoulderDesign, edge);
+    var currentBounds = (Rect)Call(window, "ShapeRect")!;
+    Check(currentBounds.Contains(transparentShoulder),
+        $"regression point remains inside old rectangular notch bounds on {edge}");
+    Check(!Interactive(window, transparentShoulder),
+        $"transparent notch shoulder passes through on {edge}");
 }
 
 Console.WriteLine($"{passed} input-region checks passed.");

--- a/tests/EdgePilot.InputChecks/Program.cs
+++ b/tests/EdgePilot.InputChecks/Program.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using EdgePilot.Core;
+using EdgePilot.UI;
+
+AppBuilder.Configure<Application>()
+    .UseSkia()
+    .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+    .SetupWithoutStarting();
+
+const BindingFlags Flags = BindingFlags.Instance | BindingFlags.NonPublic;
+var passed = 0;
+
+void Check(bool condition, string name)
+{
+    if (!condition) throw new Exception(name);
+    Console.WriteLine("PASS " + name);
+    passed++;
+}
+
+object? Call(EdgeWindow window, string name, params object[] args) =>
+    typeof(EdgeWindow).GetMethod(name, Flags)!.Invoke(window, args);
+
+void Set(EdgeWindow window, string name, object value) =>
+    typeof(EdgeWindow).GetField(name, Flags)!.SetValue(window, value);
+
+Rect[] Regions(EdgeWindow window) => (Rect[])Call(window, "InteractiveRects")!;
+bool Interactive(EdgeWindow window, Point point) => (bool)Call(window, "IsInteractive", point)!;
+
+var window = new EdgeWindow();
+
+foreach (var edge in Enum.GetValues<EdgeSide>())
+{
+    var size = NotchLayout.WindowSize(edge);
+    var windowRect = new Rect(size);
+
+    window.ApplyPreferences(new NotchPreferences(edge, NotchDisplayMode.Hover)
+    {
+        Sensitivity = HoverSensitivity.Normal
+    });
+    Set(window, "_expanded", false);
+    Set(window, "_expansion", 0d);
+    Call(window, "UpdateNotchVisual");
+
+    var collapsed = Regions(window);
+    var hot = (Rect)Call(window, "HotZoneRect")!;
+    var shape = (Rect)Call(window, "ShapeRect")!;
+    Check(collapsed.Length == 2, $"hover collapsed exposes only hot-zone and shape on {edge}");
+    Check(collapsed.All(windowRect.Contains), $"collapsed regions stay inside window on {edge}");
+    Check(collapsed.All(r => r.Width * r.Height < size.Width * size.Height),
+        $"collapsed regions never become the full transparent window on {edge}");
+    Check(Interactive(window, hot.Center), $"hover hot-zone remains interactive on {edge}");
+    Check(Interactive(window, shape.Center), $"collapsed notch remains interactive on {edge}");
+    Check(!Interactive(window, windowRect.Center), $"transparent window center passes through on {edge}");
+
+    Set(window, "_expanded", true);
+    Set(window, "_expansion", 1d);
+    Call(window, "UpdateNotchVisual");
+    var expanded = Regions(window);
+    Check(expanded.Length == 2, $"expanded hover keeps hot-zone and notch only on {edge}");
+    Check(expanded.All(windowRect.Contains), $"expanded regions stay inside window on {edge}");
+    Check(!Interactive(window, windowRect.Center), $"expanded transparent area passes through on {edge}");
+
+    Call(window, "SetHoveredMetric", 0);
+    var withTooltip = Regions(window);
+    var tooltip = (Rect)Call(window, "TooltipLiveRect")!;
+    var bridge = (Rect)Call(window, "BridgeRect")!;
+    Check(withTooltip.Length == 4, $"tooltip adds only card and bridge on {edge}");
+    Check(tooltip.Width > 0 && tooltip.Height > 0 && Interactive(window, tooltip.Center),
+        $"tooltip stays interactive on {edge}");
+    Check(bridge.Width > 0 && bridge.Height > 0 && Interactive(window, bridge.Center),
+        $"tooltip bridge stays interactive on {edge}");
+    Check(withTooltip.All(windowRect.Contains), $"tooltip regions stay inside window on {edge}");
+
+    window.ApplyPreferences(new NotchPreferences(edge, NotchDisplayMode.Hidden));
+    Check(Regions(window).Length == 0, $"hidden mode has an empty native input region on {edge}");
+    Check(!Interactive(window, hot.Center), $"hidden mode accepts no pointer input on {edge}");
+
+    window.ApplyPreferences(new NotchPreferences(edge, NotchDisplayMode.Always));
+    Set(window, "_expanded", true);
+    Set(window, "_expansion", 1d);
+    Call(window, "UpdateNotchVisual");
+    var always = Regions(window);
+    Check(always.Length == 1, $"always mode exposes only the current notch without tooltip on {edge}");
+    Check(always.All(windowRect.Contains), $"always region stays inside window on {edge}");
+    Check(!Interactive(window, windowRect.Center), $"always mode transparent area passes through on {edge}");
+}
+
+Console.WriteLine($"{passed} input-region checks passed.");


### PR DESCRIPTION
## Summary

This PR addresses the input-routing failure reported in #16 on **both Windows and Linux** without changing the notch layout, spring animation, transparency model, Signals work, or Glass work.

Refs #16

## Root cause

`EdgeWindow` is intentionally larger than the visible notch (`410x620` on left/right, rotated on top/bottom) so it can contain spring animation, all four edge orientations and the detail tooltip.

Visual transparency does not by itself make that native top-level safe for input.

### Windows

The existing implementation relied on `WM_NCHITTEST` returning `HTTRANSPARENT` outside EdgePilot's logical interaction areas. That is not a sufficient cross-application click-through guarantee: Win32 documents `HTTRANSPARENT` as continuing hit testing through underlying windows belonging to the **same thread**. Browser and desktop windows normally belong to other processes/threads, which explains why the large transparent EdgePilot HWND could still interfere with controls underneath in real Windows use.

Reference: https://learn.microsoft.com/windows/win32/inputdev/wm-nchittest

### Linux

There was no equivalent native input constraint at all. The transparent Avalonia X11/XWayland top-level remained a rectangular native input surface, so invisible parts of the topmost `410x620` window could receive pointer input and make browser/website controls behind it appear non-interactive.

### Second-instance observation

This is a separate issue, not the cause of click blocking. The existing named `Mutex` used the .NET 10 default session-local scope; on Unix-like systems different shells/desktop sessions can therefore acquire different mutex instances for the same user.

## Fix

### Shared live-region model

EdgePilot now has one definition of the areas it is allowed to own for input:

- the **actual curved notch silhouette**, represented by conservative one-DIP scanline strips instead of its rectangular bounds;
- the configured Hover hot-zone, only in Hover mode;
- the visible tooltip;
- the tooltip bridge.

Hidden mode exposes no live input surface. Logical strip boundaries are quantized to the nearest native pixel so adjacent strips share a boundary at fractional DPI instead of cutting one-pixel seams through the animated notch.

The Hover hot-zone remains intentionally transparent and interactive because that small edge area is what wakes the collapsed notch. Everything else in the larger layout surface must pass through.

### Windows

- Replace `HTTRANSPARENT` as the correctness mechanism with a real native `HWND` window region.
- Build the composed region efficiently and apply it with `SetWindowRgn`.
- Reapply it as the spring, tooltip, scaling or preferences change.
- Read the applied region back once with `GetWindowRgn` and compare it to the expected region, so package smoke does not treat a merely attempted region update as success.
- Because points outside the HWND region are not part of the EdgePilot window for native hit testing, clicks can reach browser/desktop windows owned by other applications.

### Linux X11 / XWayland

- Resolve the Avalonia native `XID` after the window opens.
- Apply the same live rectangles through X Shape `ShapeInput` using an independent XCB connection.
- Send the SHAPE update as a checked XCB request, so the display server must actually accept the region before EdgePilot considers the surface safe.
- Require the XCB Shape runtime library (`libxcb-shape.so.0`; `libxcb-shape0` on Debian/Ubuntu/Parrot).
- `install.sh` detects a missing runtime library and prints the exact Debian-family install command instead of installing a package that cannot safely expose the notch.

### Fail-closed behavior

On Windows or Linux, if EdgePilot cannot establish its safe native region, the edge surface is hidden instead of leaving a large transparent topmost rectangle capable of blocking the user's desktop.

### Single instance

The named mutex is now explicitly scoped with `CurrentUserOnly=true` and `CurrentSessionOnly=false`, so terminal/launcher/autostart sessions for the same user share the same primary instance.

## Wayland

The current Avalonia desktop configuration uses X11 by default, including XWayland on Wayland desktops, so the X Shape input-region path applies there.

Avalonia's native Wayland backend is experimental/opt-in and is not enabled by this project. If that backend is enabled in the future and no equivalent safe compositor-supported input-region mechanism is available, this PR deliberately preserves the fail-closed rule rather than falling back to a rectangular click-blocking overlay.

## Regression coverage

`EdgePilot.InputChecks` runs on Windows and Ubuntu CI and verifies all four edges. Coverage includes:

- Hover exposes only hot-zone + current notch silhouette when no tooltip is shown;
- the transparent center of the larger native window is never interactive;
- points inside the **old rectangular notch bounds but outside the visible shoulder** pass through;
- expanded Hover remains constrained;
- tooltip and bridge remain interactive;
- Hidden has an empty interaction region;
- Always exposes only the notch silhouette when no tooltip is shown;
- all live rectangles remain within the window bounds;
- adjacent scanlines retain a shared native-pixel boundary at fractional DPI.

Package smoke tests also require native input-region initialization on both platforms. Windows verifies the applied `HWND` region. Ubuntu installs/checks the declared XCB Shape runtime dependency and exercises a checked X11 SHAPE request under Xvfb. Its second packaged launch runs through `setsid` so CI also verifies that the singleton remains one-per-user across Unix sessions.

Existing checks still run:

- repository/privacy checks;
- Windows + Ubuntu build;
- existing notch UX checks;
- EN / IT / FR / ES localization checks;
- self-contained publish;
- Windows/Ubuntu package and install checks.

## Manual validation still required

This PR intentionally remains **Draft** and uses `Refs #16`, not `Fixes #16`.

Before marking ready or claiming #16 is resolved, the maintainer still needs real-desktop validation on **both Windows and Linux**:

- browser buttons behind transparent parts of the large EdgePilot layout remain clickable;
- collapsed and expanded Hover behavior and all sensitivity levels;
- right-click Settings;
- pin/unpin;
- tooltip crossing/bridge;
- all four edges;
- Hidden / Hover / Always;
- mixed DPI / monitor movement where available;
- Linux X11/XWayland behavior on a real compositor/window manager.

No response should be posted to the reporter and #16 should remain open until that manual validation is complete.