### PR TITLE
ci: skip draft refresh when preview is already published

### DIFF
--- a/.github/workflows/draft-preview.yml
+++ b/.github/workflows/draft-preview.yml
@@ -46,7 +46,10 @@ jobs:
           cd ..
           tag=v0.1.0-preview.1
           if state=$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null); then
-            test "$state" = true || { echo 'Refusing to modify a published release.'; exit 1; }
+            if [ "$state" != true ]; then
+              echo "Release $tag is already published; artifacts verified, skipping draft refresh."
+              exit 0
+            fi
             gh release edit "$tag" --draft --prerelease --target "$RELEASE_SHA" --notes-file docs/releases/v0.1.0-preview.1.md
           else
             gh release create "$tag" --draft --prerelease --target "$RELEASE_SHA" --title "EdgePilot $tag" --notes-file docs/releases/v0.1.0-preview.1.md


### PR DESCRIPTION
## What changed

`draft-preview` currently fails after every successful push to `main` once `v0.1.0-preview.1` has been published, even though the build artifacts and SHA256 checks are valid.

This keeps the existing safety rule (never mutate a published release) but treats that state as a clean skip instead of a workflow failure:

- artifacts are still downloaded and verified;
- an existing draft is still refreshed;
- a missing preview draft is still created;
- an already-published preview now exits successfully with an explicit message.

This removes the false-red Actions result without changing release contents or weakening the published-release guard.