### PR TITLE
Harden v0.2 CI and release preparation

### DIFF
--- a/.github/workflows/brand-assets.yml
+++ b/.github/workflows/brand-assets.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - run: python -m pip install Pillow==12.3.0 CairoSVG==2.8.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/v0.1-system-monitor
   workflow_dispatch:
   pull_request:
     branches:
@@ -18,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Check documentation and private commit attribution
@@ -45,15 +44,15 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Set up Python for asset and package checks
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -130,6 +129,11 @@ jobs:
           timeout 20s xvfb-run -a dist/EdgePilot/EdgePilot --smoke-test &
           smoke_pid=$!
           sleep 2
+          if ! kill -0 "$smoke_pid" 2>/dev/null; then
+            echo 'Primary instance exited prematurely or native input-region initialization failed.' >&2
+            wait "$smoke_pid"
+            exit 1
+          fi
           # A new Unix session must still resolve to the same per-user EdgePilot instance.
           timeout 6s setsid dist/EdgePilot/EdgePilot --settings
           wait "$smoke_pid"
@@ -143,7 +147,7 @@ jobs:
 
       - name: Upload Windows package
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: EdgePilot-win-x64
           path: |
@@ -153,7 +157,7 @@ jobs:
 
       - name: Upload Ubuntu package
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: EdgePilot-linux-x64
           path: |

--- a/.github/workflows/draft-preview.yml
+++ b/.github/workflows/draft-preview.yml
@@ -22,11 +22,11 @@ jobs:
       group: preview-draft
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -44,14 +44,30 @@ jobs:
           sha256sum -c EdgePilot-win-x64.sha256
           sha256sum -c EdgePilot-linux-x64.sha256
           cd ..
-          tag=v0.1.0-preview.1
+
+          version=$(python - <<'PY'
+          import xml.etree.ElementTree as ET
+          root = ET.parse('src/EdgePilot/EdgePilot.csproj').getroot()
+          node = root.find('.//Version')
+          if node is None or not (node.text or '').strip():
+              raise SystemExit('EdgePilot.csproj does not contain a Version value')
+          print(node.text.strip())
+          PY
+          )
+          tag="v${version}"
+          notes="docs/releases/${tag}.md"
+          if [ ! -f "$notes" ]; then
+            echo "Missing release notes for $tag: $notes" >&2
+            exit 1
+          fi
+
           if state=$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null); then
             if [ "$state" != true ]; then
               echo "Release $tag is already published; artifacts verified, skipping draft refresh."
               exit 0
             fi
-            gh release edit "$tag" --draft --prerelease --target "$RELEASE_SHA" --notes-file docs/releases/v0.1.0-preview.1.md
+            gh release edit "$tag" --draft --prerelease --target "$RELEASE_SHA" --notes-file "$notes"
           else
-            gh release create "$tag" --draft --prerelease --target "$RELEASE_SHA" --title "EdgePilot $tag" --notes-file docs/releases/v0.1.0-preview.1.md
+            gh release create "$tag" --draft --prerelease --target "$RELEASE_SHA" --title "EdgePilot $tag" --notes-file "$notes"
           fi
           gh release upload "$tag" release-assets/EdgePilot-win-x64.zip release-assets/EdgePilot-win-x64.sha256 release-assets/EdgePilot-linux-x64.tar.gz release-assets/EdgePilot-linux-x64.sha256 --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The v0.2 preview turns the initial system-monitor settings panel into a more coh
 - Translator documentation and repository checks for locale key parity and invalid/missing translation keys.
 - Canonical SVG rendering inside Settings and About, while retaining a generated native ICO for Windows integration.
 - Product-focused About page with author attribution, GitHub repository/profile links and local-first principles.
-- Dedicated localization regression suite running on Windows and Ubuntu CI.
+- Dedicated localization and native input-region regression suites running on Windows and Ubuntu CI.
 
 ### Changed
 
@@ -27,6 +27,14 @@ The v0.2 preview turns the initial system-monitor settings panel into a more coh
 - Changing language preserves the currently open Settings page when the window is rebuilt.
 - Settings save/reset state, labels, descriptions, icons and responsive behavior were redesigned without removing existing preferences.
 - Product positioning now describes EdgePilot as an edge-native desktop surface; the System monitor is the first module rather than the whole product.
+- Preview release automation now derives its tag from the application version instead of carrying a hard-coded release tag.
+- GitHub Actions workflows use current Node 24-compatible action generations.
+
+### Fixed
+
+- Transparent portions of the large edge window no longer intercept clicks intended for browser or desktop controls. Native input is constrained to live EdgePilot regions on Windows and X11/XWayland (#16/#17).
+- Single-instance activation is hardened so a second launch resolves to the existing per-user EdgePilot instance instead of leaving duplicate desktop surfaces.
+- CI package smoke processes now terminate deterministically instead of depending on desktop-lifetime teardown timing.
 
 ### Contributors
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,50 +2,49 @@
 
 ## Repository readiness
 
-- [ ] Resolve any remaining private-history references before changing visibility.
-- [ ] Confirm the latest main build is green, including repository checks and both packaged desktop checks.
+- [ ] Confirm the latest `main` build is green, including repository checks and both packaged desktop checks.
+- [ ] Confirm the application version in `src/EdgePilot/EdgePilot.csproj` is the intended preview version.
+- [ ] Confirm `docs/releases/v<version>.md` exists and matches the changelog.
 - [ ] Review README screenshots and known limitations.
 - [ ] Review the MIT license and third-party notices included in the archives.
 - [ ] Complete the manual Windows/Ubuntu checks below.
-- [ ] Review the draft preview release and its four downloadable files.
+- [ ] Review the generated draft pre-release and its four downloadable files.
 
-Repository preparation does not automatically make the repository public or publish a draft release.
-
-## Suggested GitHub settings
-
-Description: **A compact screen-edge system monitor for Windows and Linux, built with Avalonia and .NET.**
-
-Topics: edgepilot, system-monitor, desktop, windows, linux, avalonia, dotnet, csharp.
-
-Keep main as the default branch. Enable private vulnerability reporting and available secret scanning/push protection. After history cleanup, consider requiring pull requests and successful checks before merging into main. Availability depends on repository visibility and GitHub plan.
+The repository ruleset requires pull requests and successful Windows, Ubuntu and repository checks before `main` can move. A green CI run does not publish a release automatically.
 
 ## Draft release automation
 
-After a successful push build on main, the draft-preview workflow downloads that exact run's verified packages and creates or updates the **draft**, **pre-release** named v0.1.0-preview.1. It refuses to overwrite an already published release.
+After a successful **push** build on `main`, `.github/workflows/draft-preview.yml` downloads the packages produced by that exact build, verifies both SHA-256 files and reads the release version directly from `src/EdgePilot/EdgePilot.csproj`.
 
-The workflow does not publish the release. Review its notes and assets, then publish manually when ready. Future versions require updating the application Version, changelog, release notes and workflow tag together.
+For version `X.Y.Z-preview.N`, the workflow uses:
 
-Archives contain the .NET runtime, the icon, installation instructions, project license and dependency notices. SHA-256 files use the archive basename so verification works after download.
+- tag `vX.Y.Z-preview.N`;
+- notes file `docs/releases/vX.Y.Z-preview.N.md`.
+
+If the matching release does not exist, the workflow creates a **draft pre-release**. If it is still a draft, the workflow refreshes its target, notes and assets. If that version has already been published, the workflow verifies the new build artifacts and exits without modifying the published release.
+
+The workflow never publishes a release. Review the draft manually before publishing it.
+
+### Starting a new preview version
+
+Update these together:
+
+1. `<Version>` in `src/EdgePilot/EdgePilot.csproj`;
+2. `CHANGELOG.md`;
+3. `docs/releases/v<version>.md`.
+
+Do **not** hard-code the new tag in the workflow; release automation derives it from the project version.
+
+Archives contain the .NET runtime, application icon/assets, installation instructions, project license and dependency notices. SHA-256 files use the archive basename so verification still works after download.
 
 ## Manual desktop checks
 
-- Windows 11: launch, all four edges, hover/fold/pin, tooltip transitions, scaling, tray and hidden-mode recovery.
-- Ubuntu: record distribution and desktop session; verify transparency, tray support and settings under light/dark themes.
-- Both: choose the intended volume, restart, confirm selection, and test the unavailable-volume state.
+- Windows 11: launch, all four edges, hover/fold/pin, tooltip transitions, Settings, tray, hidden-mode recovery and relevant Glass modes.
+- Windows 10 when supported by the feature set: launch, Acrylic/Flat availability and fallback behavior.
+- Ubuntu: record distribution and desktop session; verify transparency, native input region, tray support and Settings under light/dark themes.
+- Both: test common scaling where available, choose the intended volume, restart, confirm selection, and test the unavailable-volume state.
+- Both: verify a second launch activates the existing instance instead of creating a duplicate surface.
 - Both: install for the current user, enable startup, log out/in, then disable startup and confirm it is removed.
-- Exit before upgrading; verify the installed launcher still opens the app.
+- Exit before upgrading; verify the installed launcher still opens the new build.
 
-CI smoke checks do not replace actual login or compositor testing.
-
-## Updating copies after a history cleanup
-
-Do not merge an old local branch into the cleaned history. The safest route is a fresh clone into a **new** directory, keeping the old directory untouched until any local work has been recovered:
-
-```bash
-git clone https://github.com/pricootz/edgepilot.git edgepilot-clean
-cd edgepilot-clean
-git config user.email "58367058+pricootz@users.noreply.github.com"
-dotnet run --project src/EdgePilot/EdgePilot.csproj -c Release -- --settings
-```
-
-Run this from the parent projects directory, choosing another unused name if edgepilot-clean already exists. Copy only reviewed uncommitted source changes if necessary; do not push old branches or .git data.
+CI smoke checks do not replace actual login, compositor, scaling or physical multi-monitor testing.

--- a/docs/releases/v0.2.0-preview.1.md
+++ b/docs/releases/v0.2.0-preview.1.md
@@ -1,0 +1,37 @@
+# EdgePilot v0.2.0-preview.1
+
+The v0.2 preview turns EdgePilot from the first system-monitor prototype into a more complete edge-native desktop surface, with a redesigned Settings experience, scalable localization and safer desktop input handling.
+
+## Highlights
+
+- Redesigned responsive Settings window with dedicated General, Edge, Monitor, Behavior, Startup and About sections.
+- Italian, English, French and Spanish interface localization, automatic system-language detection and a persisted manual override.
+- File-based locale discovery so additional translations can be contributed as standalone JSON catalogs.
+- Interactive metric cards, contextual disk configuration and clearer controls for edge placement, display mode, refresh interval and hover sensitivity.
+- Canonical SVG branding in the app, with generated native Windows icon assets.
+- Safer transparent-edge input routing on Windows and X11/XWayland: only live EdgePilot regions accept pointer input, so transparent window areas no longer block browser or desktop controls.
+- Hardened single-instance activation so starting EdgePilot again activates the existing instance instead of leaving duplicate desktop surfaces.
+- Expanded Windows and Ubuntu regression coverage for UX, localization, native input regions, package launch and per-user installation.
+
+## Existing system monitor
+
+The current System module continues to provide local CPU and memory usage, disk capacity, network download/upload rates, selected system details, four-edge placement, hover/fold/pin behavior, tooltips, tray controls and optional start at login.
+
+## Platform notes
+
+- Packages are self-contained **x64** builds for Windows and Linux.
+- On Debian/Ubuntu/Parrot, Linux input-region support requires `libxcb-shape0`; `install.sh` checks for it before installation.
+- The Linux desktop path currently uses X11/XWayland input regions. Native Wayland support is not enabled yet.
+- Packages are unsigned and updates are manual.
+- Display scaling, physical multi-monitor layouts and login-session behavior still need broader real-desktop coverage before a stable release.
+
+## Upgrade
+
+Exit the running EdgePilot instance before replacing an existing preview. Extract the complete archive and follow the included `README.md`; use `Install.ps1` on Windows or `install.sh` on Linux for per-user installation.
+
+## Contributors
+
+- IT / EN / FR localization foundation: [@IamArayel](https://github.com/IamArayel), originally contributed through PR #5.
+- File-based locale architecture, translator workflow and Spanish localization: [@ArnieGA](https://github.com/ArnieGA), through PRs #8 and #12.
+
+Please report regressions with the EdgePilot version, operating system, desktop/session type and exact reproduction steps.

--- a/scripts/check_repository.py
+++ b/scripts/check_repository.py
@@ -1,9 +1,10 @@
-"""Check repository links, locale catalogs and private commit attribution."""
+"""Check repository links, locale catalogs, release metadata and private commit attribution."""
 from pathlib import Path
 from urllib.parse import unquote
 import json
 import re
 import subprocess
+import xml.etree.ElementTree as ET
 
 root = Path.cwd().resolve()
 errors = []
@@ -20,6 +21,27 @@ for doc in root.rglob("*.md"):
         target = (doc.parent / unquote(link.split("#")[0])).resolve()
         if not target.exists():
             errors.append(f"Missing link target in {doc.relative_to(root)}: {link}")
+
+# The app version is the release source of truth. Every version must have matching
+# changelog coverage and a notes file before a main build can prepare a draft release.
+project_path = root / "src" / "EdgePilot" / "EdgePilot.csproj"
+try:
+    project = ET.parse(project_path).getroot()
+    version_node = project.find(".//Version")
+    version = (version_node.text or "").strip() if version_node is not None else ""
+except (ET.ParseError, OSError) as exc:
+    version = ""
+    errors.append(f"Cannot read EdgePilot version from {project_path.relative_to(root)}: {exc}")
+
+if not version:
+    errors.append("src/EdgePilot/EdgePilot.csproj must define a non-empty Version")
+else:
+    release_notes = root / "docs" / "releases" / f"v{version}.md"
+    if not release_notes.is_file():
+        errors.append(f"Missing release notes for project version {version}: {release_notes.relative_to(root)}")
+    changelog_path = root / "CHANGELOG.md"
+    if not changelog_path.is_file() or f"## {version}" not in changelog_path.read_text(encoding="utf-8"):
+        errors.append(f"CHANGELOG.md does not contain a section for project version {version}")
 
 # Scan published branch history; GitHub's legacy pull refs and caches require a separate check.
 emails = subprocess.check_output(
@@ -84,4 +106,4 @@ for required in ("LICENSE", "README.md", "SECURITY.md", "CONTRIBUTING.md", "THIR
 
 if errors:
     raise SystemExit("\n".join(errors))
-print("Documentation links, locale catalogs, required documents and private commit attribution passed.")
+print("Documentation links, release metadata, locale catalogs, required documents and private commit attribution passed.")

--- a/src/EdgePilot/App.cs
+++ b/src/EdgePilot/App.cs
@@ -97,13 +97,13 @@ public sealed class App : Application
                     if ((OperatingSystem.IsWindows() || OperatingSystem.IsLinux()) && !window.HasSafePlatformInput)
                     {
                         Console.Error.WriteLine("EdgePilot could not establish a safe native input region.");
-                        Environment.ExitCode = 2;
-                        // Shutting down synchronously from Opened can tear down Avalonia while its
-                        // desktop lifetime is still entering StartCore. Defer by one dispatcher turn.
-                        DispatcherTimer.RunOnce(() => desktop.Shutdown(), TimeSpan.FromMilliseconds(1));
+                        Environment.Exit(2);
                         return;
                     }
-                    DispatcherTimer.RunOnce(() => desktop.Shutdown(), TimeSpan.FromSeconds(8));
+
+                    // The smoke process is disposable CI infrastructure. Exiting explicitly avoids
+                    // desktop-lifetime races where native/tray windows keep Xvfb alive after Shutdown().
+                    DispatcherTimer.RunOnce(() => Environment.Exit(0), TimeSpan.FromSeconds(8));
                 }
                 if ((preferences.Mode == NotchDisplayMode.Hidden &&
                     (!window.HasTray || desktop.Args?.Contains("--autostart") != true)) || warning is not null ||

--- a/tests/EdgePilot.UxChecks/EdgePilot.UxChecks.csproj
+++ b/tests/EdgePilot.UxChecks/EdgePilot.UxChecks.csproj
@@ -8,6 +8,5 @@
   <ItemGroup>
     <ProjectReference Include="../../src/EdgePilot/EdgePilot.csproj" />
     <PackageReference Include="Avalonia.Headless" Version="12.1.2" />
-    <Compile Include="../../src/EdgePilot/UI/NotchSpring.cs" Link="NotchSpring.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

Before promoting Glass or Signals, clean up the v0.2 repository/release foundation so CI failures are meaningful and preview automation follows the actual application version.

## Changes

- update GitHub Actions to current Node 24-compatible major generations (`checkout@v7`, `setup-dotnet@v6`, `setup-python@v7`, `download-artifact@v8`, `upload-artifact@v7`);
- remove the stale special push trigger for the old `feat/v0.1-system-monitor` branch;
- make the disposable `--smoke-test` process exit deterministically after native input-region validation instead of depending on Avalonia desktop lifetime teardown;
- add an early Linux package check that the primary smoke instance is still alive before testing single-instance activation;
- stop compiling `NotchSpring.cs` twice in `EdgePilot.UxChecks`;
- derive draft preview tags from `<Version>` in `src/EdgePilot/EdgePilot.csproj` rather than hard-coding v0.1;
- require matching `CHANGELOG.md` coverage and `docs/releases/v<version>.md` in repository checks;
- add v0.2.0-preview.1 release notes and update the release guide/changelog.

## Context

The Linux package smoke timeout seen on Glass #19 was non-deterministic: the exact failed job passed unchanged on rerun. This PR removes the lifetime race instead of increasing the timeout.

This PR intentionally does **not** change EdgePilot notch geometry, input behavior, Glass styling or Signals functionality.
