### PR TITLE
Stabilize v0.2 preview packaging and validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,11 @@ jobs:
           Copy-Item packaging/Install.ps1 dist/EdgePilot/
           Copy-Item packaging/README.md dist/EdgePilot/
           $exe = (Resolve-Path dist/EdgePilot/EdgePilot.exe).Path
+          $expectedVersion = (dotnet msbuild src/EdgePilot/EdgePilot.csproj -getProperty:Version).Trim()
+          $reportedVersion = (& $exe --version | Out-String).Trim()
+          if ($reportedVersion -ne "EdgePilot $expectedVersion") {
+            throw "Package version mismatch. Expected EdgePilot $expectedVersion, got $reportedVersion"
+          }
           $smoke = Start-Process -FilePath $exe -ArgumentList '--smoke-test' -PassThru -WindowStyle Hidden
           Start-Sleep -Milliseconds 1500
           if ($smoke.HasExited) { throw 'Primary instance exited prematurely or native input-region initialization failed.' }
@@ -126,6 +131,9 @@ jobs:
         run: |
           cp packaging/install.sh packaging/README.md dist/EdgePilot/
           chmod +x dist/EdgePilot/EdgePilot dist/EdgePilot/install.sh
+          expected_version="$(dotnet msbuild src/EdgePilot/EdgePilot.csproj -getProperty:Version)"
+          reported_version="$(dist/EdgePilot/EdgePilot --version)"
+          test "$reported_version" = "EdgePilot $expected_version"
           timeout 20s xvfb-run -a dist/EdgePilot/EdgePilot --smoke-test &
           smoke_pid=$!
           sleep 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## 0.2.0-preview.1 — 2026-09-11
+## 0.2.0-preview.2 — 2026-09-12
+
+A focused stabilization update for the v0.2 preview. It does not add a new product module.
+
+### Fixed
+
+- The packaged `--version` diagnostic reports the full preview identity instead of dropping the prerelease suffix.
+
+### Verification and documentation
+
+- Package CI now verifies that the version reported by Windows and Linux executables exactly matches the project version.
+- Settings regression coverage now includes the supported minimum window size and both responsive layout modes.
+- Native input-region coverage now explicitly runs at 100%, 125%, 150% and 200% scaling.
+- Documentation distinguishes basic display-topology awareness from selectable multi-monitor targeting, which is not implemented yet.
+- The screenshot inventory now identifies the Settings/overview captures that predate the v0.2 redesign instead of presenting them as current.
+- The publication review records the current public-release state and the remaining GitHub-managed historical attribution follow-up.
+
+## 0.2.0-preview.1 — 2026-09-12
 
 The v0.2 preview turns the initial system-monitor settings panel into a more coherent EdgePilot product surface and establishes localization as a first-class capability.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 No account, server or telemetry uploader is required. The interface ships in **Italian, English, French and Spanish**, follows the system language automatically, and can be extended with additional locale files.
 
 <p align="center">
-  <img src="docs/assets/windows11-notch.png" width="150" alt="Expanded EdgePilot notch showing system metrics on Windows 11">
+  <img src="docs/assets/windows11-notch.png" width="150" alt="Expanded EdgePilot Flat notch showing system metrics on Windows 11">
 </p>
-<p align="center">The current System module running from the screen edge.</p>
+<p align="center">The System module using the Flat surface from the screen edge.</p>
 
 ## v0.2 at a glance
 
@@ -96,7 +96,7 @@ python scripts/check_repository.py
 - Current packages target **x64**. macOS, ARM packages and headless SSH sessions are not supported targets.
 - Linux transparency, positioning and tray visibility depend on the desktop/compositor. A GNOME AppIndicator extension may be needed.
 - The current Linux desktop path uses X11/XWayland input regions; Avalonia's native Wayland backend is not enabled by this project.
-- Display scaling, multiple monitors and login behavior still need broader real-desktop testing.
+- Display scaling, display-topology changes and login behavior still need broader real-desktop testing. Selectable multi-monitor targeting is not implemented yet.
 - Disk selection follows a drive letter or mount path, not a hardware serial number.
 - Network interface selection is automatic. Temperatures, GPU and fan readings are not implemented.
 - Packages are unsigned and updates are manual. This is not yet a stable release.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,8 @@ Linux desktop-entry comments are generated for every shipped locale so desktop m
 
 `EdgeWindow` owns interaction state and rendering. `EdgeNotchGeometry` supplies the shared silhouette and clip; `NotchLayout` maps geometry and hit targets to all four edges while preserving upright text. `NotchSpring` retains motion continuity when a transition reverses. `MetricRing` and `DisplayFormat` present snapshots.
 
+Placement uses Avalonia's screen containing the Edge window, falling back to the primary screen, and recalculates when the desktop screen collection changes. v0.2 does not persist a display identity or expose selectable multi-monitor targeting.
+
 `SettingsWindow` owns Settings state and navigation. Page composition lives under `UI/Settings`, keeping General, Edge, Monitor, Behavior, Startup and About separate from reusable controls.
 
 `NotchPreferences` stores persisted interface state including edge, display mode, visible metrics, refresh, hover sensitivity, selected disk, language and Settings theme. `PreferenceStore` saves atomically and preserves compatibility with the original v0.2 language values.

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -20,13 +20,13 @@ CI regenerates the derived assets on Ubuntu and fails if the committed ICO or re
 
 ## Screenshots
 
-The Windows 11 screenshots are maintainer-supplied, unaltered application captures of the current preview:
+The Windows 11 gallery was captured for the initial v0.1 preview. It remains useful as a visual baseline, but it is not a complete representation of v0.2:
 
-- [Settings and expanded notch](assets/windows11-overview.png)
-- [Complete settings](assets/windows11-settings.png), including disk selection and start at login
-- [Expanded notch](assets/windows11-notch.png), with CPU, memory and disk enabled
-- [Collapsed pill](assets/windows11-pill.png)
+- [Settings and expanded notch](assets/windows11-overview.png) predates the v0.2 multi-page Settings redesign.
+- [Complete settings](assets/windows11-settings.png) predates the v0.2 multi-page Settings redesign.
+- [Expanded notch](assets/windows11-notch.png) still illustrates the supported Flat System surface.
+- [Collapsed pill](assets/windows11-pill.png) still illustrates the supported Flat System surface.
 
-The interface remains Italian. These captures replace the earlier Windows settings image.
+Do not use the old Settings/overview captures to claim the current v0.2 or Windows Glass appearance. Replace them with real unaltered captures of the redesigned Settings window under relevant Flat/Mica/Acrylic and Light/Dark combinations.
 
 Add Ubuntu captures when available, including light/dark settings themes and a collapsed/expanded notch pair. Avoid private hostnames and drive labels. A checked startup option in a screenshot does not replace verification after an actual login.

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -34,4 +34,4 @@ Signals are being developed separately and are not part of the current `main` pr
 
 ## Not current scope
 
-Remote servers, Docker, clipboard tools, VPN/Tailscale, removable-device workflows and quick actions are future ideas, not shipped features. GPU, temperature and fan sensors are not part of this preview. macOS and ARM packages are not current supported targets.
+Remote servers, Docker, clipboard tools, VPN/Tailscale, removable-device workflows and quick actions are future ideas, not shipped features. Selectable multi-monitor targeting and per-display EdgePilot surfaces are not implemented. GPU, temperature and fan sensors are not part of this preview. macOS and ARM packages are not current supported targets.

--- a/docs/PUBLICATION-CHECK.md
+++ b/docs/PUBLICATION-CHECK.md
@@ -1,10 +1,10 @@
-# Publication preparation — 2026-09-07
+# Publication preparation and v0.2 follow-up — 2026-09-12
 
 ## Completed preparation
 
 - English README, installation and developer documentation.
 - MIT license, contribution and security guidance, issue and pull request templates.
-- Four current, maintainer-supplied Windows 11 screenshots: overview, complete settings, expanded notch and collapsed pill.
+- Four maintainer-supplied Windows 11 captures from the initial preview. The notch/pill still illustrate the Flat System surface; Settings/overview predate the v0.2 redesign and require replacement.
 - Original icon preserved; adapted transparent master and generated PNG/multi-resolution ICO.
 - Dependency metadata and available license/notice files included in packages.
 - Relative documentation link checks and private commit-attribution checks.
@@ -16,18 +16,18 @@
 
 The pre-preparation review inspected 24 development commits, 96 unique file blobs (95 text files and one ICO), both branch tips, and existing pull-request references. Pattern checks did not identify credential formats in the inspected text. One personal commit email was replaced in both active branch histories at the maintainer's request.
 
-The two initial screenshot PNGs and original icon inspected during the pre-preparation review contained no text or EXIF metadata chunks. The screenshot gallery was subsequently replaced with four current Windows 11 captures. The adapted master retains generation provenance metadata; application PNG/ICO exports contain pixel data.
+The two initial screenshot PNGs and original icon inspected during the pre-preparation review contained no text or EXIF metadata chunks. The gallery was subsequently expanded to four initial-preview Windows 11 captures; its Settings/overview images now predate the v0.2 redesign. The adapted master retains generation provenance metadata; application PNG/ICO exports contain pixel data.
 
 These checks reduce risk; they are not a guarantee that every possible secret format, external cache, fork or local clone has been examined.
 
-## Publication hold
+## Historical attribution follow-up
 
-GitHub can retain old commits through closed pull-request references and cached commit pages after branch history is rewritten. The existing legacy pull-request reference still needs GitHub-side cleanup before a strict claim of complete email removal can be made.
+GitHub can retain old commits through closed pull-request references and cached commit pages after branch history is rewritten. The legacy pull-request references still need GitHub-side cleanup before a strict claim of complete email removal can be made.
 
-Keep the repository private until that is resolved. GitHub Support determines whether it can remove the retained references; a clean replacement repository is an alternative if cleanup is unavailable. Do not copy the old Git history into that replacement.
+The repository and v0.2 preview are now public. The history reachable from current `main` passes the private-attribution check. A 2026-09-12 audit still found non-noreply attribution fields in two closed pull-request references; ordinary branch pushes cannot rewrite GitHub-managed pull references. GitHub Support determines whether those retained references can be removed if strict historical cleanup is still desired.
 
 Follow [GitHub's removal guidance](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository). No private email or old affected commit identifier is reproduced here.
 
 ## Still useful before a stable release
 
-Ubuntu screenshots, real login/startup checks, multiple-display/DPI checks and wider desktop feedback. See [the release checklist](RELEASING.md).
+Current v0.2 Windows screenshots, Ubuntu screenshots, real login/startup checks, display-topology/DPI checks and wider desktop feedback. Selectable multi-monitor targeting is not part of v0.2. See [the release checklist](RELEASING.md).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,8 +43,9 @@ Archives contain the .NET runtime, application icon/assets, installation instruc
 - Windows 10 when supported by the feature set: launch, Acrylic/Flat availability and fallback behavior.
 - Ubuntu: record distribution and desktop session; verify transparency, native input region, tray support and Settings under light/dark themes.
 - Both: test common scaling where available, choose the intended volume, restart, confirm selection, and test the unavailable-volume state.
+- With more than one display: verify safe repositioning after topology changes. Do not claim selectable multi-monitor targeting until that feature exists.
 - Both: verify a second launch activates the existing instance instead of creating a duplicate surface.
 - Both: install for the current user, enable startup, log out/in, then disable startup and confirm it is removed.
 - Exit before upgrading; verify the installed launcher still opens the new build.
 
-CI smoke checks do not replace actual login, compositor, scaling or physical multi-monitor testing.
+CI smoke checks do not replace actual login, compositor, scaling or physical display-topology testing.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,12 +30,13 @@ This roadmap is directional, not a delivery schedule.
 
 ## Before promoting v0.2 beyond preview
 
-- [ ] Broader Windows 11 and Ubuntu desktop testing.
+- [x] Hands-on Windows 10 and Windows 11 checks for supported Flat/Mica/Acrylic surfaces and input safety.
+- [ ] Broader Ubuntu desktop testing.
 - [ ] Verify real logout/login startup and tray behavior.
 - [ ] Test Settings at common scaling levels (100%, 125%, 150%) and smaller window sizes.
-- [ ] Validate all four edges and monitor changes on physical multi-monitor systems.
+- [ ] Validate all four edges and safe repositioning when physical display topology changes. Selectable multi-monitor targeting is not a v0.2 feature.
 - [ ] Confirm language switching and Automatic mode on Italian, English, French and Spanish desktop locales.
-- [ ] Add current v0.2 Windows and Ubuntu screenshots.
+- [ ] Replace the pre-v0.2 Settings/overview captures with current Windows screenshots and add Ubuntu captures.
 - [ ] Gather feedback from the preview release.
 
 ## v0.3 direction — Signals / ambient awareness

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -24,6 +24,8 @@ Controls where EdgePilot lives and how it appears.
 - **Position:** right, left, top or bottom edge, with a live visual preview.
 - **Panel behavior:** on hover, always visible or hidden.
 
+v0.2 does not expose a display selector or create one EdgePilot surface per display. Multi-monitor targeting is a future feature, separate from choosing one of the four edges.
+
 ## Monitor
 
 Controls the current System module.

--- a/docs/releases/v0.2.0-preview.1.md
+++ b/docs/releases/v0.2.0-preview.1.md
@@ -28,7 +28,7 @@ The current System module continues to provide local CPU and memory usage, disk 
 - On Debian/Ubuntu/Parrot, Linux input-region support requires `libxcb-shape0`; `install.sh` checks for it before installation.
 - The Linux desktop path currently uses X11/XWayland input regions and Flat surface. Native Wayland Glass support is not enabled yet.
 - Packages are unsigned and updates are manual.
-- Display scaling, physical multi-monitor layouts and login-session behavior still need broader real-desktop coverage before a stable release.
+- Display scaling, physical display-topology changes and login-session behavior still need broader real-desktop coverage before a stable release. Selectable multi-monitor targeting is not implemented yet.
 
 ## Upgrade
 

--- a/docs/releases/v0.2.0-preview.2.md
+++ b/docs/releases/v0.2.0-preview.2.md
@@ -1,0 +1,29 @@
+# EdgePilot v0.2.0-preview.2
+
+This is a focused stabilization update for the v0.2 preview. It keeps the application behavior and visual surface introduced in preview.1 while tightening package identity, automated validation and public documentation.
+
+## Changes
+
+- `EdgePilot --version` now reports the complete `0.2.0-preview.2` identity instead of the numeric assembly version `0.2.0.0`.
+- Windows and Linux package jobs verify that the executable reports exactly the version declared by the project.
+- Settings checks cover both the regular layout and the supported 680 × 520 minimum window layout.
+- Native input-region checks explicitly cover 100%, 125%, 150% and 200% scaling.
+- Documentation now distinguishes display-topology awareness from selectable multi-monitor targeting, which is not implemented yet.
+- The screenshot inventory identifies captures that predate the redesigned v0.2 Settings experience and still need replacement.
+- The publication review reflects the current public repository/release state and preserves the remaining historical-attribution follow-up without reproducing personal fields.
+
+## Existing v0.2 behavior
+
+The redesigned Settings experience, IT/EN/FR/ES localization, Flat/Mica/Acrylic support, safe transparent-edge input routing, single-instance recovery and local CPU/memory/disk/network monitoring are unchanged from preview.1.
+
+## Platform notes
+
+- Packages remain self-contained **x64** builds for Windows and Linux.
+- Windows 10 build 17134 (1803)+ supports Flat and Acrylic; Windows 11 build 22000+ additionally supports Mica.
+- Linux currently uses X11/XWayland input regions and the Flat surface; `libxcb-shape0` is required on Debian/Ubuntu/Parrot.
+- Selectable multi-monitor targeting, native Wayland Glass, signed packages and automatic updates are not implemented.
+- Real logout/login startup checks, broader Ubuntu coverage, physical display-topology changes and current v0.2 screenshot capture remain open before a stable release.
+
+## Upgrade
+
+Exit EdgePilot before replacing the previous preview. Extract the complete archive and follow the included `README.md`; use `Install.ps1` on Windows or `install.sh` on Linux for per-user installation.

--- a/src/EdgePilot/Core/ProductVersion.cs
+++ b/src/EdgePilot/Core/ProductVersion.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+
+namespace EdgePilot.Core;
+
+public static class ProductVersion
+{
+    public static string Value
+    {
+        get
+        {
+            var assembly = typeof(ProductVersion).Assembly;
+            var informational = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion?
+                .Split('+')[0];
+            if (!string.IsNullOrWhiteSpace(informational)) return informational;
+
+            return assembly.GetName().Version?.ToString() ?? "unknown";
+        }
+    }
+
+    public static string Label => Value == "unknown" ? "Preview" : $"v{Value}";
+}

--- a/src/EdgePilot/EdgePilot.csproj
+++ b/src/EdgePilot/EdgePilot.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ApplicationIcon>Assets/edgepilot.ico</ApplicationIcon>
-    <Version>0.2.0-preview.1</Version>
+    <Version>0.2.0-preview.2</Version>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/src/EdgePilot/Program.cs
+++ b/src/EdgePilot/Program.cs
@@ -12,7 +12,7 @@ internal static class Program
         Localization.SetLanguage(Localization.DetectSystemLanguage());
         if (args.Contains("--version"))
         {
-            Console.WriteLine("EdgePilot " + typeof(Program).Assembly.GetName().Version);
+            Console.WriteLine("EdgePilot " + ProductVersion.Value);
             return;
         }
         if (args.Contains("--install"))

--- a/src/EdgePilot/UI/SettingsWindow.cs
+++ b/src/EdgePilot/UI/SettingsWindow.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
@@ -603,14 +602,7 @@ public sealed partial class SettingsWindow : GlassWindow
         return version.ToUpperInvariant();
     }
 
-    private static string FullVersionLabel()
-    {
-        var informational = typeof(SettingsWindow).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-            .InformationalVersion?
-            .Split('+')[0];
-        return string.IsNullOrWhiteSpace(informational) ? "Preview" : $"v{informational}";
-    }
+    private static string FullVersionLabel() => ProductVersion.Label;
 
     private static IBrush Brush(string color) => new SolidColorBrush(Color.Parse(color));
 

--- a/tests/EdgePilot.InputChecks/Program.cs
+++ b/tests/EdgePilot.InputChecks/Program.cs
@@ -167,22 +167,25 @@ window.ApplyPreferences(new NotchPreferences());
 
 var platformType = typeof(EdgeWindow).Assembly.GetType("EdgePilot.Platform.PlatformInputRegion")!;
 var toNative = platformType.GetMethod("ToNativeRectangles", BindingFlags.Static | BindingFlags.NonPublic)!;
-var nativeArray = (Array)toNative.Invoke(null, new object[]
+foreach (var scale in new[] { 1d, 1.25d, 1.5d, 2d })
 {
-    new[]
+    var nativeArray = (Array)toNative.Invoke(null, new object[]
     {
-        new Rect(100.2, 50.1, 20.4, 1.0),
-        new Rect(100.2, 51.1, 20.4, 1.0)
-    },
-    1.25d,
-    new Size(NotchLayout.DesignWidth, NotchLayout.DesignHeight)
-})!;
-Check(nativeArray.Length == 2, "fractional-DPI scanlines survive native quantization");
-var nativeType = nativeArray.GetType().GetElementType()!;
-var first = nativeArray.GetValue(0)!;
-var second = nativeArray.GetValue(1)!;
-var bottom = (int)nativeType.GetField("Bottom", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(first)!;
-var top = (int)nativeType.GetField("Top", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(second)!;
-Check(bottom == top, "fractional-DPI scanlines share a native pixel boundary");
+        new[]
+        {
+            new Rect(100.2, 50.1, 20.4, 1.0),
+            new Rect(100.2, 51.1, 20.4, 1.0)
+        },
+        scale,
+        new Size(NotchLayout.DesignWidth, NotchLayout.DesignHeight)
+    })!;
+    Check(nativeArray.Length == 2, $"DPI {scale:0.##} scanlines survive native quantization");
+    var nativeType = nativeArray.GetType().GetElementType()!;
+    var first = nativeArray.GetValue(0)!;
+    var second = nativeArray.GetValue(1)!;
+    var bottom = (int)nativeType.GetField("Bottom", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(first)!;
+    var top = (int)nativeType.GetField("Top", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(second)!;
+    Check(bottom == top, $"DPI {scale:0.##} scanlines share a native pixel boundary");
+}
 
 Console.WriteLine($"{passed} input-region checks passed.");

--- a/tests/EdgePilot.UxChecks/Program.cs
+++ b/tests/EdgePilot.UxChecks/Program.cs
@@ -60,6 +60,12 @@ Check(DriveSelection.Choices(manyDrives, null).Count == 13, "selector does not t
 Check(DriveSelection.Choices(drives, null)[2].Caption.Contains("16 TB"), "decimal disk capacity is recognizable");
 _ = AppIcon.Load();
 Check(true, "embedded tray icon decodes");
+var informationalVersion = typeof(ProductVersion).Assembly
+    .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?
+    .InformationalVersion?
+    .Split('+')[0];
+Check(ProductVersion.Value == informationalVersion && ProductVersion.Label == $"v{informationalVersion}",
+    "product version preserves preview identity");
 var window = new EdgeWindow();
 Call(window, "UpdatePointer", new Point(405, 310));
 Check((bool)Field(window, "_expanded")!, "hot-zone opens");
@@ -270,6 +276,42 @@ try
     Check(exitIcon.Icon == FluentIcons.Common.Icon.SignOut, "exit action uses SignOut icon");
     Check(exitIcon.IconSize == FluentIcons.Common.IconSize.Size20 && Math.Abs(exitIcon.FontSize - 16) < 0.001,
         "compact exit icon uses available glyph set at 16px");
+
+    var settingsBody = (Grid)SettingsField(settings, "_body")!;
+    var versionBadge = (Border)SettingsField(settings, "_versionBadge")!;
+    var previewLayout = (Grid)SettingsField(settings, "_previewLayout")!;
+    var positionOptions = (StackPanel)SettingsField(settings, "_positionOptions")!;
+    var previewFrame = (Border)SettingsField(settings, "_previewFrame")!;
+    var metricGrid = (Grid)SettingsField(settings, "_metricGrid")!;
+    var metricTiles = (Border[])SettingsField(settings, "_metricTiles")!;
+    Check(settings.MinWidth == 680 && settings.MinHeight == 520,
+        "settings exposes the supported minimum window size");
+
+    SettingsCall(settings, "ApplyResponsiveLayout", 920d);
+    Check(Math.Abs(settingsBody.ColumnDefinitions[0].Width.Value - 184) < 0.001,
+        "regular settings layout uses full navigation width");
+    Check(versionBadge.IsVisible, "regular settings layout shows version badge");
+    Check(previewLayout.ColumnDefinitions.Count == 2 && previewLayout.RowDefinitions.Count == 1 &&
+        Grid.GetColumn(positionOptions) == 1 && Grid.GetRow(positionOptions) == 0,
+        "regular edge preview uses two columns");
+    Check(metricGrid.ColumnDefinitions.Count == 2 && metricGrid.RowDefinitions.Count == 2 &&
+        metricTiles.Select(Grid.GetColumn).SequenceEqual(new[] { 0, 1, 0, 1 }) &&
+        metricTiles.Select(Grid.GetRow).SequenceEqual(new[] { 0, 0, 1, 1 }),
+        "regular metric cards use a two-column grid");
+
+    SettingsCall(settings, "ApplyResponsiveLayout", 680d);
+    Check(Math.Abs(settingsBody.ColumnDefinitions[0].Width.Value - 154) < 0.001,
+        "minimum settings layout compacts navigation");
+    Check(!versionBadge.IsVisible, "minimum settings layout hides version badge");
+    Check(previewLayout.ColumnDefinitions.Count == 1 && previewLayout.RowDefinitions.Count == 2 &&
+        Grid.GetColumn(positionOptions) == 0 && Grid.GetRow(positionOptions) == 1 &&
+        previewFrame.Width == 260 && previewFrame.Height == 158,
+        "minimum edge preview stacks without clipping its frame");
+    Check(metricGrid.ColumnDefinitions.Count == 1 && metricGrid.RowDefinitions.Count == 4 &&
+        metricTiles.All(tile => Grid.GetColumn(tile) == 0) &&
+        metricTiles.Select(Grid.GetRow).SequenceEqual(new[] { 0, 1, 2, 3 }),
+        "minimum metric cards use a single-column grid");
+    SettingsCall(settings, "ApplyResponsiveLayout", 920d);
 
     SettingsCall(settings, "SelectEdge", EdgeSide.Bottom, true);
     SettingsCall(settings, "SelectMode", NotchDisplayMode.Always, true);


### PR DESCRIPTION
## Summary

- bump the stabilization build to `0.2.0-preview.2` instead of silently changing the already-published preview.1 binary;
- make `EdgePilot --version` preserve the full prerelease identity;
- verify executable/project version parity in both Windows and Linux package jobs;
- cover the 680 × 520 Settings layout and both responsive modes;
- cover native input-region quantization at 100%, 125%, 150% and 200% scaling;
- clarify that v0.2 reacts to display-topology changes but does not yet provide selectable multi-monitor targeting;
- identify the Settings/overview screenshots that predate the v0.2 redesign;
- update the publication review to reflect the public repository/release and remaining GitHub-managed historical attribution follow-up.

No new product module or visual behavior is introduced.

## Validation completed locally

- Release build: 0 warnings, 0 errors
- UX: 1,728 checks passed
- Input region: 142 checks passed
- Localization: 29 checks passed
- Repository/release metadata validation: passed
- NuGet vulnerability audit: no known vulnerable packages
- Linux self-contained package: generated with license/notices/assets; reports `EdgePilot 0.2.0-preview.2`
- Windows self-contained package: generated; native executable/version smoke will run on Windows CI

## Manual release status

The preview.1 application surface was already checked on Windows 10 and Windows 11. Remaining work before a stable v0.2 is intentionally documented: broader Ubuntu desktop coverage, real logout/login startup behavior, physical display-topology changes, wider feedback, and current Windows/Ubuntu screenshots.